### PR TITLE
Fixed port name in service monitor

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -178,7 +178,7 @@ in for `prom` when it appears.
 ### Monitoring Your Application
 
 In order to monitor your application, you'll need to set up
-a ServiceMonitor pointing at the application.  Assuming you've set up your
+a ServiceMonitor pointing at the service for the application.  Assuming you've set up your
 Prometheus instance to use ServiceMonitors with the `app: sample-app`
 label, create a ServiceMonitor to monitor the app's metrics via the
 service:

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -199,7 +199,7 @@ spec:
     matchLabels:
       app: sample-app
   endpoints: 
-  - port: http
+  - port: 80-8080
 ```
 
 </details>


### PR DESCRIPTION
The way the service is created here creates a port named 80-8080 and not http. This causes this example to not work.