### PR TITLE
add endTime variable for promeClient.Series api

### DIFF
--- a/pkg/custom-provider/provider.go
+++ b/pkg/custom-provider/provider.go
@@ -218,6 +218,7 @@ type selectorSeries struct {
 
 func (l *cachingMetricsLister) updateMetrics() error {
 	startTime := pmodel.Now().Add(-1 * l.maxAge)
+	endTime := pmodel.Now().Add(1 * l.maxAge)
 
 	// don't do duplicate queries when it's just the matchers that change
 	seriesCacheByQuery := make(map[prom.Selector][]prom.Series)
@@ -236,7 +237,7 @@ func (l *cachingMetricsLister) updateMetrics() error {
 		}
 		selectors[sel] = struct{}{}
 		go func() {
-			series, err := l.promClient.Series(context.TODO(), pmodel.Interval{startTime, 0}, sel)
+			series, err := l.promClient.Series(context.TODO(), pmodel.Interval{startTime, endTime}, sel)
 			if err != nil {
 				errs <- fmt.Errorf("unable to fetch metrics for query %q: %v", sel, err)
 				return

--- a/pkg/custom-provider/provider_test.go
+++ b/pkg/custom-provider/provider_test.go
@@ -87,7 +87,8 @@ var _ = Describe("Custom Metrics Provider", func() {
 
 		By("setting the acceptible interval to now until the next update, with a bit of wiggle room")
 		startTime := pmodel.Now().Add(-1*fakeProviderUpdateInterval - fakeProviderUpdateInterval/10)
-		fakeProm.AcceptableInterval = pmodel.Interval{Start: startTime, End: 0}
+		endTime := pmodel.Now().Add(1*fakeProviderUpdateInterval + fakeProviderUpdateInterval/10)
+		fakeProm.AcceptableInterval = pmodel.Interval{Start: startTime, End: endTime}
 
 		By("updating the list of available metrics")
 		// don't call RunUntil to avoid timing issue

--- a/pkg/external-provider/basic_metric_lister.go
+++ b/pkg/external-provider/basic_metric_lister.go
@@ -84,6 +84,7 @@ func (l *basicMetricLister) ListAllMetrics() (MetricUpdateResult, error) {
 	}
 
 	startTime := pmodel.Now().Add(-1 * l.lookback)
+	endTime := pmodel.Now().Add(1 * l.lookback)
 
 	// these can take a while on large clusters, so launch in parallel
 	// and don't duplicate
@@ -99,7 +100,7 @@ func (l *basicMetricLister) ListAllMetrics() (MetricUpdateResult, error) {
 		}
 		selectors[sel] = struct{}{}
 		go func() {
-			series, err := l.promClient.Series(context.TODO(), pmodel.Interval{startTime, 0}, sel)
+			series, err := l.promClient.Series(context.TODO(), pmodel.Interval{startTime, endTime}, sel)
 			if err != nil {
 				errs <- fmt.Errorf("unable to fetch metrics for query %q: %v", sel, err)
 				return


### PR DESCRIPTION
Currently, when Prometheus adapter querying Prometheus series API to updating metrics, It's hardcoded set `endtime` parameter to 0, which means we won't set endtime parameter in prometheus query URL

https://github.com/DirectXMan12/k8s-prometheus-adapter/blob/master/pkg/client/api.go#L152
```
	if interval.End != 0 {
		vals.Set("end", interval.End.String())
	}
```

then Prometheus will set A very large default time as `endtime` to query its backend storage, this might be failed, and return no metrics data.

I add value to `endtime`, It might alleviate this potential issue. 

related issue: https://github.com/m3db/m3/issues/2471

Signed-off-by: 屈骏 <qujun@tiduyun.com>