### PR TITLE
fix walkthrough example

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -94,9 +94,33 @@ spec:
 
 </details>
 
+<details>
+
+<summary>sample-app.service.yaml</summary>
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: sample-app
+  name: sample-app
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: sample-app
+  type: ClusterIP
+```
+
+</details>
+
 ```shell
 $ kubectl create -f sample-app.deploy.yaml
-$ kubectl create service clusterip sample-app --tcp=80:8080
+$ kubectl create -f sample-app.service.yaml
 ```
 
 Now, check your app, which exposes metrics and counts the number of
@@ -198,7 +222,7 @@ spec:
   selector:
     matchLabels:
       app: sample-app
-  endpoints: 
+  endpoints:
   - port: http
 ```
 
@@ -335,7 +359,7 @@ You should see that it succesfully fetched the metric, but it hasn't tried
 to scale, since there's not traffic.
 
 Since your app is going to need to scale in response to traffic, generate
-some via cURL like above: 
+some via cURL like above:
 
 ```shell
 $ curl http://$(kubectl get service sample-app -o jsonpath='{ .spec.clusterIP }')/metrics


### PR DESCRIPTION
fixes #378 

This PR makes sure, the ServiceMonitor and the Service port name match each other.