### PR TITLE
Allow metrics to be defined as `namespaced: false`

### DIFF
--- a/docs/externalmetrics.md
+++ b/docs/externalmetrics.md
@@ -1,0 +1,84 @@
+External Metrics
+===========
+
+It's possible to configure [Autoscaling on metrics not related to Kubernetes objects](Autoscaling on metrics not related to Kubernetes objects) in Kubernetes. This is done with a special `External Metrics` system. Using external metrics in Kubernetes with the adapter requires you to configure special `external` rules in the configuration.
+
+The configuration for `external` metrics rules is almost identical to the normal `rules`:
+
+```yaml
+external:
+- seriesQuery: '{__name__="queue_consumer_lag",name!=""}'
+  metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (name)
+  resources:
+    overrides: { namespace: {resource: "namespace"} }
+```
+
+Namespacing
+-----------
+
+All Kubernetes Horizontal Pod Autoscaler (HPA) resources are namespaced. And when you create an HPA that
+references an external metric the adapter will automatically add a `namespace` label to the `seriesQuery` you have configured.
+
+This is done because the External Merics API Specification *requires* a namespace component in the URL:
+
+```shell
+kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/default/queue_consumer_lag"
+```
+
+Cross-Namespace or No Namespace Queries
+---------------------------------------
+
+A semi-common scenario is to have a `workload` in one namespace that needs to scale based on a metric from a different namespace. This is normally not
+possible with `external` rules because the `namespace` label is set to match that of the source `workload`.
+
+However, you can explicitly disable the automatic add of the HPA namepace to the query, and instead opt to not set a namespace at all, or to target a different namespace.
+
+This is done by setting `namespaced: false` the `resources` section of the `external` rule:
+
+```yaml
+# rules: ...
+
+external:
+- seriesQuery: '{__name__="queue_depth",name!=""}'
+  metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (name)
+  resources:
+    namespaced: false
+```
+
+Given the `external` rules defined above any `External` metric query for `queue_depth` will simply ignore the source `namespace` of the HPA. This allows you to explicilty not put a namespace into an external query, or to set the namespace to one that might be different from that of the HPA.
+
+```yaml
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: external-queue-scaler
+  # the HPA and scaleTargetRef must exist in a namespace
+  namespace: default
+  annotations:
+    # The "External" metric below targets a metricName that has namespaced=false
+    # and this allows the metric to explicitly query a different
+    # namespace than that of the HPA and scaleTargetRef
+    autoscaling.alpha.kubernetes.io/metrics: |
+      [
+        {
+            "type": "External",
+            "external": {
+                "metricName": "queue_depth",
+                "metricSelector": {
+                    "matchLabels": {
+                        "namespace": "queue",
+                        "name": "my-sample-queue"
+                    }
+                },
+                "targetAverageValue": "50"
+            }
+        }
+      ]
+spec:
+  maxReplicas: 5
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: my-app
+```

--- a/docs/externalmetrics.md
+++ b/docs/externalmetrics.md
@@ -1,7 +1,7 @@
 External Metrics
 ===========
 
-It's possible to configure [Autoscaling on metrics not related to Kubernetes objects](Autoscaling on metrics not related to Kubernetes objects) in Kubernetes. This is done with a special `External Metrics` system. Using external metrics in Kubernetes with the adapter requires you to configure special `external` rules in the configuration.
+It's possible to configure [Autoscaling on metrics not related to Kubernetes objects](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-metrics-not-related-to-kubernetes-objects) in Kubernetes. This is done with a special `External Metrics` system. Using external metrics in Kubernetes with the adapter requires you to configure special `external` rules in the configuration.
 
 The configuration for `external` metrics rules is almost identical to the normal `rules`:
 
@@ -33,7 +33,7 @@ possible with `external` rules because the `namespace` label is set to match tha
 
 However, you can explicitly disable the automatic add of the HPA namepace to the query, and instead opt to not set a namespace at all, or to target a different namespace.
 
-This is done by setting `namespaced: false` the `resources` section of the `external` rule:
+This is done by setting `namespaced: false` in the `resources` section of the `external` rule:
 
 ```yaml
 # rules: ...

--- a/docs/sample-config.yaml
+++ b/docs/sample-config.yaml
@@ -65,5 +65,18 @@ rules:
       brand: {group: "cheese.io", resource: "brand"}
   metricQuery: 'count(cheddar{sharp="true"})'
 
+# external rules are not tied to a Kubernetes resource and can reference any metric
+# https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-metrics-not-related-to-kubernetes-objects
+external:
+- seriesQuery: '{__name__="queue_consumer_lag",name!=""}'
+  metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (name)
+- seriesQuery: '{__name__="queue_depth",topic!=""}'
+  metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (name)
+  # Kubernetes metric queries include a namespace in the query by default
+  # but you can explicitly disable namespaces if needed with "namespaced: false"
+  # this is useful if you have an HPA with an external metric in namespace A
+  # but want to query for metrics from namespace B
+  namespaced: false
+
 # TODO: should we be able to map to a constant instance of a resource
 # (e.g. `resources: {constant: [{resource: "namespace", name: "kube-system"}}]`)?

--- a/docs/sample-config.yaml
+++ b/docs/sample-config.yaml
@@ -76,7 +76,8 @@ external:
   # but you can explicitly disable namespaces if needed with "namespaced: false"
   # this is useful if you have an HPA with an external metric in namespace A
   # but want to query for metrics from namespace B
-  namespaced: false
+  resources:
+    namespaced: false
 
 # TODO: should we be able to map to a constant instance of a resource
 # (e.g. `resources: {constant: [{resource: "namespace", name: "kube-system"}}]`)?

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,6 +58,8 @@ type ResourceMapping struct {
 	// Overrides specifies exceptions to the above template, mapping label names
 	// to group-resources
 	Overrides map[string]GroupResource `json:"overrides,omitempty" yaml:"overrides,omitempty"`
+	//Namespaced ignores the source namespace of the requester and requires one in the query
+	Namespaced *bool `json:"namespaced,omitempty" yaml:"namespaced,omitempty"`
 }
 
 // GroupResource represents a Kubernetes group-resource.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,7 +58,7 @@ type ResourceMapping struct {
 	// Overrides specifies exceptions to the above template, mapping label names
 	// to group-resources
 	Overrides map[string]GroupResource `json:"overrides,omitempty" yaml:"overrides,omitempty"`
-	//Namespaced ignores the source namespace of the requester and requires one in the query
+	// Namespaced ignores the source namespace of the requester and requires one in the query
 	Namespaced *bool `json:"namespaced,omitempty" yaml:"namespaced,omitempty"`
 }
 

--- a/pkg/naming/metric_namer.go
+++ b/pkg/naming/metric_namer.go
@@ -159,7 +159,7 @@ func NamersFromConfig(cfg []config.DiscoveryRule, mapper apimeta.RESTMapper) ([]
 			namespaced = *rule.Resources.Namespaced
 		}
 
-		metricsQuery, err := NewMetricsQuery(rule.MetricsQuery, resConv, namespaced)
+		metricsQuery, err := NewExternalMetricsQuery(rule.MetricsQuery, resConv, namespaced)
 		if err != nil {
 			return nil, fmt.Errorf("unable to construct metrics query associated with series query %q: %v", rule.SeriesQuery, err)
 		}

--- a/pkg/naming/metric_namer.go
+++ b/pkg/naming/metric_namer.go
@@ -102,8 +102,13 @@ type metricNamer struct {
 	nameMatches    *regexp.Regexp
 	nameAs         string
 	seriesMatchers []*ReMatcher
+	namespaced     *bool
 
 	ResourceConverter
+}
+
+func (n *metricNamer) isNamespaced() bool {
+	return (n.namespaced != nil) && *n.namespaced
 }
 
 // queryTemplateArgs are the arguments for the metrics query template.
@@ -131,8 +136,10 @@ func (n *metricNamer) QueryForSeries(series string, resource schema.GroupResourc
 }
 
 func (n *metricNamer) QueryForExternalSeries(series string, namespace string, metricSelector labels.Selector) (prom.Selector, error) {
-	//test := prom.Selector()
-	//return test, nil
+	if !n.isNamespaced() {
+		namespace = ""
+	}
+
 	return n.metricsQuery.BuildExternal(series, namespace, "", []string{}, metricSelector)
 }
 
@@ -207,6 +214,7 @@ func NamersFromConfig(cfg []config.DiscoveryRule, mapper apimeta.RESTMapper) ([]
 			nameMatches:       nameMatches,
 			nameAs:            nameAs,
 			seriesMatchers:    seriesMatchers,
+			namespaced:        rule.Resources.Namespaced,
 			ResourceConverter: resConv,
 		}
 

--- a/pkg/naming/metrics_query.go
+++ b/pkg/naming/metrics_query.go
@@ -90,7 +90,7 @@ type queryPart struct {
 func (q *metricsQuery) Build(series string, resource schema.GroupResource, namespace string, extraGroupBy []string, metricSelector labels.Selector, names ...string) (prom.Selector, error) {
 	queryParts := q.createQueryPartsFromSelector(metricSelector)
 
-	if q.namespaced && namespace != "" {
+	if namespace != "" {
 		namespaceLbl, err := q.resConverter.LabelForResource(NsGroupResource)
 		if err != nil {
 			return "", err

--- a/pkg/naming/metrics_query.go
+++ b/pkg/naming/metrics_query.go
@@ -50,7 +50,27 @@ type MetricsQuery interface {
 // - LabelMatchersByName: the raw map-form of the above matchers
 // - GroupBy: the group-by clause to use for the resources in the query (stringified)
 // - GroupBySlice: the raw slice form of the above group-by clause
-func NewMetricsQuery(queryTemplate string, resourceConverter ResourceConverter, namespaced bool) (MetricsQuery, error) {
+func NewMetricsQuery(queryTemplate string, resourceConverter ResourceConverter) (MetricsQuery, error) {
+	templ, err := template.New("metrics-query").Delims("<<", ">>").Parse(queryTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse metrics query template %q: %v", queryTemplate, err)
+	}
+
+	return &metricsQuery{
+		resConverter: resourceConverter,
+		template:     templ,
+		namespaced:   true,
+	}, nil
+}
+
+// NewExternalMetricsQuery constructs a new MetricsQuery by compiling the given Go template.
+// The delimiters on the template are `<<` and `>>`, and it may use the following fields:
+// - Series: the series in question
+// - LabelMatchers: a pre-stringified form of the label matchers for the resources in the query
+// - LabelMatchersByName: the raw map-form of the above matchers
+// - GroupBy: the group-by clause to use for the resources in the query (stringified)
+// - GroupBySlice: the raw slice form of the above group-by clause
+func NewExternalMetricsQuery(queryTemplate string, resourceConverter ResourceConverter, namespaced bool) (MetricsQuery, error) {
 	templ, err := template.New("metrics-query").Delims("<<", ">>").Parse(queryTemplate)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse metrics query template %q: %v", queryTemplate, err)

--- a/pkg/naming/metrics_query_test.go
+++ b/pkg/naming/metrics_query_test.go
@@ -76,7 +76,7 @@ func checks(cs ...checkFunc) checkFunc {
 
 func TestBuildSelector(t *testing.T) {
 	mustNewQuery := func(queryTemplate string, namespaced bool) MetricsQuery {
-		mq, err := NewMetricsQuery(queryTemplate, &resourceConverterMock{namespaced}, true)
+		mq, err := NewMetricsQuery(queryTemplate, &resourceConverterMock{namespaced})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -272,7 +272,7 @@ func TestBuildSelector(t *testing.T) {
 
 func TestBuildExternalSelector(t *testing.T) {
 	mustNewQuery := func(queryTemplate string) MetricsQuery {
-		mq, err := NewMetricsQuery(queryTemplate, &resourceConverterMock{true}, true)
+		mq, err := NewExternalMetricsQuery(queryTemplate, &resourceConverterMock{true}, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -280,7 +280,7 @@ func TestBuildExternalSelector(t *testing.T) {
 	}
 
 	mustNewNonNamespacedQuery := func(queryTemplate string) MetricsQuery {
-		mq, err := NewMetricsQuery(queryTemplate, &resourceConverterMock{true}, false)
+		mq, err := NewExternalMetricsQuery(queryTemplate, &resourceConverterMock{true}, false)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/naming/metrics_query_test.go
+++ b/pkg/naming/metrics_query_test.go
@@ -83,14 +83,6 @@ func TestBuildSelector(t *testing.T) {
 		return mq
 	}
 
-	mustNewNonNamespacedQuery := func(queryTemplate string, namespaced bool) MetricsQuery {
-		mq, err := NewMetricsQuery(queryTemplate, &resourceConverterMock{namespaced}, false)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return mq
-	}
-
 	mustNewLabelRequirement := func(key string, op selection.Operator, vals []string) *labels.Requirement {
 		req, err := labels.NewRequirement(key, op, vals)
 		if err != nil {
@@ -209,21 +201,6 @@ func TestBuildSelector(t *testing.T) {
 			check: checks(
 				hasError(nil),
 				hasSelector("default bar|baz"),
-			),
-		},
-
-		{
-			name: "multiple LabelValuesByName values with namespace disabled",
-
-			mq:             mustNewNonNamespacedQuery(`<<index .LabelValuesByName "namespaces">> <<index .LabelValuesByName "resource">>`, true),
-			metricSelector: labels.NewSelector(),
-			resource:       schema.GroupResource{Group: "group", Resource: "resource"},
-			namespace:      "default",
-			names:          []string{"bar", "baz"},
-
-			check: checks(
-				hasError(nil),
-				hasSelector(" bar|baz"),
 			),
 		},
 

--- a/pkg/resourceprovider/provider.go
+++ b/pkg/resourceprovider/provider.go
@@ -54,11 +54,11 @@ func newResourceQuery(cfg config.ResourceRule, mapper apimeta.RESTMapper) (resou
 		return resourceQuery{}, fmt.Errorf("unable to construct label-resource converter: %v", err)
 	}
 
-	contQuery, err := naming.NewMetricsQuery(cfg.ContainerQuery, converter)
+	contQuery, err := naming.NewMetricsQuery(cfg.ContainerQuery, converter, true)
 	if err != nil {
 		return resourceQuery{}, fmt.Errorf("unable to construct container metrics query: %v", err)
 	}
-	nodeQuery, err := naming.NewMetricsQuery(cfg.NodeQuery, converter)
+	nodeQuery, err := naming.NewMetricsQuery(cfg.NodeQuery, converter, true)
 	if err != nil {
 		return resourceQuery{}, fmt.Errorf("unable to construct node metrics query: %v", err)
 	}

--- a/pkg/resourceprovider/provider.go
+++ b/pkg/resourceprovider/provider.go
@@ -54,11 +54,11 @@ func newResourceQuery(cfg config.ResourceRule, mapper apimeta.RESTMapper) (resou
 		return resourceQuery{}, fmt.Errorf("unable to construct label-resource converter: %v", err)
 	}
 
-	contQuery, err := naming.NewMetricsQuery(cfg.ContainerQuery, converter, true)
+	contQuery, err := naming.NewMetricsQuery(cfg.ContainerQuery, converter)
 	if err != nil {
 		return resourceQuery{}, fmt.Errorf("unable to construct container metrics query: %v", err)
 	}
-	nodeQuery, err := naming.NewMetricsQuery(cfg.NodeQuery, converter, true)
+	nodeQuery, err := naming.NewMetricsQuery(cfg.NodeQuery, converter)
 	if err != nil {
 		return resourceQuery{}, fmt.Errorf("unable to construct node metrics query: %v", err)
 	}


### PR DESCRIPTION
When set to false, no namespace label will be set by the adapter based on the namespace
portion of the url in the request path.

This allows individual consumers to set namespace independent of the source kubernetes resource.

---

Example:

Given an adapter config like this:

```
    externalRules:
    - seriesQuery: 'nsq_topic_depth'
      resources:
        namespaced: false
```

An HPA could target a different namespace by setting it in the selector:

```
  - type: External
    external:
      metric:
        name: nsq_topic_depth
        selector:
          labelSelector:
            topic: my-topic
            namespace: nsq
```

This is useful for scaling on metrics from services that run in a differnt namespace than the source resource.