### PR TITLE
Add label value replacers to the config and query

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,16 @@ type DiscoveryRule struct {
 	// `.GroupBy` is the comma-separated expected group-by label names. The delimeters
 	// are `<<` and `>>`.
 	MetricsQuery string `json:"metricsQuery,omitempty" yaml:"metricsQuery,omitempty"`
+	// LabelValueReplacements is a list of find/replace strings that will be run against
+	// all label values before they are sent to Prometheus. This is sometimes required
+	// when prometheus labels have values that cannot be represented in Kubernetes.
+	// for example: "#" is valid as prometheus label value but not for kubernetes
+	LabelValueReplacements []LabelValueReplacement `json:"labelValueReplacements,omitempty" yaml:"labelValueReplacements,omitempty"`
+}
+
+type LabelValueReplacement struct {
+	Find    string `json:"find,omitempty" yaml:"find,omitempty"`
+	Replace string `json:"replace,omitempty" yaml:"replace,omitempty"`
 }
 
 // RegexFilter is a filter that matches positively or negatively against a regex.

--- a/pkg/naming/metric_namer.go
+++ b/pkg/naming/metric_namer.go
@@ -97,11 +97,12 @@ func (m *ReMatcher) Matches(val string) bool {
 }
 
 type metricNamer struct {
-	seriesQuery    prom.Selector
-	metricsQuery   MetricsQuery
-	nameMatches    *regexp.Regexp
-	nameAs         string
-	seriesMatchers []*ReMatcher
+	seriesQuery       prom.Selector
+	metricsQuery      MetricsQuery
+	nameMatches       *regexp.Regexp
+	nameAs            string
+	seriesMatchers    []*ReMatcher
+	labelReplacements []config.LabelValueReplacement
 
 	ResourceConverter
 }
@@ -155,7 +156,7 @@ func NamersFromConfig(cfg []config.DiscoveryRule, mapper apimeta.RESTMapper) ([]
 			return nil, err
 		}
 
-		metricsQuery, err := NewMetricsQuery(rule.MetricsQuery, resConv)
+		metricsQuery, err := NewMetricsQuery(rule.MetricsQuery, resConv, rule.LabelValueReplacements)
 		if err != nil {
 			return nil, fmt.Errorf("unable to construct metrics query associated with series query %q: %v", rule.SeriesQuery, err)
 		}

--- a/pkg/naming/metrics_query_test.go
+++ b/pkg/naming/metrics_query_test.go
@@ -76,7 +76,7 @@ func checks(cs ...checkFunc) checkFunc {
 
 func TestBuildSelector(t *testing.T) {
 	mustNewQuery := func(queryTemplate string, namespaced bool) MetricsQuery {
-		mq, err := NewMetricsQuery(queryTemplate, &resourceConverterMock{namespaced})
+		mq, err := NewMetricsQuery(queryTemplate, &resourceConverterMock{namespaced}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -272,7 +272,7 @@ func TestBuildSelector(t *testing.T) {
 
 func TestBuildExternalSelector(t *testing.T) {
 	mustNewQuery := func(queryTemplate string) MetricsQuery {
-		mq, err := NewMetricsQuery(queryTemplate, &resourceConverterMock{true})
+		mq, err := NewMetricsQuery(queryTemplate, &resourceConverterMock{true}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/resourceprovider/provider.go
+++ b/pkg/resourceprovider/provider.go
@@ -54,11 +54,11 @@ func newResourceQuery(cfg config.ResourceRule, mapper apimeta.RESTMapper) (resou
 		return resourceQuery{}, fmt.Errorf("unable to construct label-resource converter: %v", err)
 	}
 
-	contQuery, err := naming.NewMetricsQuery(cfg.ContainerQuery, converter)
+	contQuery, err := naming.NewMetricsQuery(cfg.ContainerQuery, converter, nil)
 	if err != nil {
 		return resourceQuery{}, fmt.Errorf("unable to construct container metrics query: %v", err)
 	}
-	nodeQuery, err := naming.NewMetricsQuery(cfg.NodeQuery, converter)
+	nodeQuery, err := naming.NewMetricsQuery(cfg.NodeQuery, converter, nil)
 	if err != nil {
 		return resourceQuery{}, fmt.Errorf("unable to construct node metrics query: %v", err)
 	}


### PR DESCRIPTION
Kubernetes labels values only support a subset of what Prometheus allows. This PR allows rules to specify value replacements to enable users to work around this limitation. Fixes #323 