### PR TITLE
Makefile: include tests from cmd directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ vendor:
 	go mod vendor
 
 test:
-	CGO_ENABLED=0 go test ./pkg/...
+	CGO_ENABLED=0 go test ./cmd/... ./pkg/...
 
 verify-gofmt:
 	./hack/gofmt-all.sh -v


### PR DESCRIPTION
Update test Makefile rule to include https://github.com/kubernetes-sigs/prometheus-adapter/blob/master/cmd/adapter/adapter_test.go

/cc @s-urbaniak 