### PR TITLE
Fix documented metrics labels to work for k8s 1.16+

### DIFF
--- a/cmd/config-gen/utils/default.go
+++ b/cmd/config-gen/utils/default.go
@@ -12,50 +12,50 @@ import (
 // DefaultConfig returns a configuration equivalent to the former
 // pre-advanced-config settings.  This means that "normal" series labels
 // will be of the form `<prefix><<.Resource>>`, cadvisor series will be
-// of the form `container_`, and have the label `pod_name`.  Any series ending
+// of the form `container_`, and have the label `pod`.  Any series ending
 // in total will be treated as a rate metric.
 func DefaultConfig(rateInterval time.Duration, labelPrefix string) *MetricsDiscoveryConfig {
 	return &MetricsDiscoveryConfig{
 		Rules: []DiscoveryRule{
 			// container seconds rate metrics
 			{
-				SeriesQuery: string(prom.MatchSeries("", prom.NameMatches("^container_.*"), prom.LabelNeq("container_name", "POD"), prom.LabelNeq("namespace", ""), prom.LabelNeq("pod_name", ""))),
+				SeriesQuery: string(prom.MatchSeries("", prom.NameMatches("^container_.*"), prom.LabelNeq("container", "POD"), prom.LabelNeq("namespace", ""), prom.LabelNeq("pod", ""))),
 				Resources: ResourceMapping{
 					Overrides: map[string]GroupResource{
 						"namespace": {Resource: "namespace"},
-						"pod_name":  {Resource: "pod"},
+						"pod":       {Resource: "pod"},
 					},
 				},
 				Name:         NameMapping{Matches: "^container_(.*)_seconds_total$"},
-				MetricsQuery: fmt.Sprintf(`sum(rate(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}[%s])) by (<<.GroupBy>>)`, pmodel.Duration(rateInterval).String()),
+				MetricsQuery: fmt.Sprintf(`sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[%s])) by (<<.GroupBy>>)`, pmodel.Duration(rateInterval).String()),
 			},
 
 			// container rate metrics
 			{
-				SeriesQuery:   string(prom.MatchSeries("", prom.NameMatches("^container_.*"), prom.LabelNeq("container_name", "POD"), prom.LabelNeq("namespace", ""), prom.LabelNeq("pod_name", ""))),
+				SeriesQuery:   string(prom.MatchSeries("", prom.NameMatches("^container_.*"), prom.LabelNeq("container", "POD"), prom.LabelNeq("namespace", ""), prom.LabelNeq("pod", ""))),
 				SeriesFilters: []RegexFilter{{IsNot: "^container_.*_seconds_total$"}},
 				Resources: ResourceMapping{
 					Overrides: map[string]GroupResource{
 						"namespace": {Resource: "namespace"},
-						"pod_name":  {Resource: "pod"},
+						"pod":       {Resource: "pod"},
 					},
 				},
 				Name:         NameMapping{Matches: "^container_(.*)_total$"},
-				MetricsQuery: fmt.Sprintf(`sum(rate(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}[%s])) by (<<.GroupBy>>)`, pmodel.Duration(rateInterval).String()),
+				MetricsQuery: fmt.Sprintf(`sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[%s])) by (<<.GroupBy>>)`, pmodel.Duration(rateInterval).String()),
 			},
 
 			// container non-cumulative metrics
 			{
-				SeriesQuery:   string(prom.MatchSeries("", prom.NameMatches("^container_.*"), prom.LabelNeq("container_name", "POD"), prom.LabelNeq("namespace", ""), prom.LabelNeq("pod_name", ""))),
+				SeriesQuery:   string(prom.MatchSeries("", prom.NameMatches("^container_.*"), prom.LabelNeq("container", "POD"), prom.LabelNeq("namespace", ""), prom.LabelNeq("pod", ""))),
 				SeriesFilters: []RegexFilter{{IsNot: "^container_.*_total$"}},
 				Resources: ResourceMapping{
 					Overrides: map[string]GroupResource{
 						"namespace": {Resource: "namespace"},
-						"pod_name":  {Resource: "pod"},
+						"pod":       {Resource: "pod"},
 					},
 				},
 				Name:         NameMapping{Matches: "^container_(.*)$"},
-				MetricsQuery: `sum(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}) by (<<.GroupBy>>)`,
+				MetricsQuery: `sum(<<.Series>>{<<.LabelMatchers>>,container!="POD"}) by (<<.GroupBy>>)`,
 			},
 
 			// normal non-cumulative metrics
@@ -97,11 +97,11 @@ func DefaultConfig(rateInterval time.Duration, labelPrefix string) *MetricsDisco
 				Resources: ResourceMapping{
 					Overrides: map[string]GroupResource{
 						"namespace": {Resource: "namespace"},
-						"pod_name":  {Resource: "pod"},
+						"pod":       {Resource: "pod"},
 						"instance":  {Resource: "node"},
 					},
 				},
-				ContainerLabel: fmt.Sprintf("%scontainer_name", labelPrefix),
+				ContainerLabel: fmt.Sprintf("%scontainer", labelPrefix),
 			},
 			Memory: ResourceRule{
 				ContainerQuery: "sum(container_memory_working_set_bytes{<<.LabelMatchers>>}) by (<<.GroupBy>>)",
@@ -109,11 +109,11 @@ func DefaultConfig(rateInterval time.Duration, labelPrefix string) *MetricsDisco
 				Resources: ResourceMapping{
 					Overrides: map[string]GroupResource{
 						"namespace": {Resource: "namespace"},
-						"pod_name":  {Resource: "pod"},
+						"pod":       {Resource: "pod"},
 						"instance":  {Resource: "node"},
 					},
 				},
-				ContainerLabel: fmt.Sprintf("%scontainer_name", labelPrefix),
+				ContainerLabel: fmt.Sprintf("%scontainer", labelPrefix),
 			},
 			Window: pmodel.Duration(rateInterval),
 		},

--- a/deploy/manifests/custom-metrics-config-map.yaml
+++ b/deploy/manifests/custom-metrics-config-map.yaml
@@ -6,44 +6,44 @@ metadata:
 data:
   config.yaml: |
     rules:
-    - seriesQuery: '{__name__=~"^container_.*",container_name!="POD",namespace!="",pod_name!=""}'
+    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
       seriesFilters: []
       resources:
         overrides:
           namespace:
             resource: namespace
-          pod_name:
+          pod:
             resource: pod
       name:
         matches: ^container_(.*)_seconds_total$
         as: ""
-      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}[1m])) by (<<.GroupBy>>)
-    - seriesQuery: '{__name__=~"^container_.*",container_name!="POD",namespace!="",pod_name!=""}'
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[1m])) by (<<.GroupBy>>)
+    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
       seriesFilters:
       - isNot: ^container_.*_seconds_total$
       resources:
         overrides:
           namespace:
             resource: namespace
-          pod_name:
+          pod:
             resource: pod
       name:
         matches: ^container_(.*)_total$
         as: ""
-      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}[1m])) by (<<.GroupBy>>)
-    - seriesQuery: '{__name__=~"^container_.*",container_name!="POD",namespace!="",pod_name!=""}'
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[1m])) by (<<.GroupBy>>)
+    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
       seriesFilters:
       - isNot: ^container_.*_total$
       resources:
         overrides:
           namespace:
             resource: namespace
-          pod_name:
+          pod:
             resource: pod
       name:
         matches: ^container_(.*)$
         as: ""
-      metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}) by (<<.GroupBy>>)
+      metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>,container!="POD"}) by (<<.GroupBy>>)
     - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
       seriesFilters:
       - isNot: .*_total$
@@ -80,9 +80,9 @@ data:
               resource: node
             namespace:
               resource: namespace
-            pod_name:
+            pod:
               resource: pod
-        containerLabel: container_name
+        containerLabel: container
       memory:
         containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>}) by (<<.GroupBy>>)
         nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'}) by (<<.GroupBy>>)
@@ -92,9 +92,9 @@ data:
               resource: node
             namespace:
               resource: namespace
-            pod_name:
+            pod:
               resource: pod
-        containerLabel: container_name
+        containerLabel: container
       window: 1m
     externalRules:
     - seriesQuery: '{__name__=~"^.*_queue_(length|size)$",namespace!=""}'

--- a/docs/config.md
+++ b/docs/config.md
@@ -31,13 +31,13 @@ might look like:
 ```yaml
 rules:
 # this rule matches cumulative cAdvisor metrics measured in seconds
-- seriesQuery: '{__name__=~"^container_.*",container_name!="POD",namespace!="",pod_name!=""}'
+- seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
   resources:
     # skip specifying generic resource<->label mappings, and just
     # attach only pod and namespace resources by mapping label names to group-resources
     overrides:
       namespace: {resource: "namespace"},
-      pod_name: {resource: "pod"},
+      pod: {resource: "pod"},
   # specify that the `container_` and `_seconds_total` suffixes should be removed.
   # this also introduces an implicit filter on metric family names
   name:
@@ -48,7 +48,7 @@ rules:
   # This is a Go template where the `.Series` and `.LabelMatchers` string values
   # are available, and the delimiters are `<<` and `>>` to avoid conflicts with
   # the prometheus query language
-  metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}[2m])) by (<<.GroupBy>>)"
+  metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)"
 ```
 
 Discovery
@@ -83,7 +83,7 @@ For example:
 
 ```yaml
 # match all cAdvisor metrics that aren't measured in seconds
-seriesQuery: '{__name__=~"^container_.*_total",container_name!="POD",namespace!="",pod_name!=""}'
+seriesQuery: '{__name__=~"^container_.*_total",container!="POD",namespace!="",pod!=""}'
 seriesFilters:
   - isNot: "^container_.*_seconds_total"
 ```
@@ -211,5 +211,5 @@ For example:
 
 ```yaml
 # convert cumulative cAdvisor metrics into rates calculated over 2 minutes
-metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}[2m])) by (<<.GroupBy>>)"
+metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)"
 ```

--- a/docs/sample-config.yaml
+++ b/docs/sample-config.yaml
@@ -10,16 +10,16 @@ rules:
 # can be found in pkg/config/default.go
 
 # this rule matches cumulative cAdvisor metrics measured in seconds
-- seriesQuery: '{__name__=~"^container_.*",container_name!="POD",namespace!="",pod_name!=""}'
+- seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
   resources:
     # skip specifying generic resource<->label mappings, and just
     # attach only pod and namespace resources by mapping label names to group-resources
     overrides:
       namespace: {resource: "namespace"},
-      pod_name: {resource: "pod"},
+      pod: {resource: "pod"},
   # specify that the `container_` and `_seconds_total` suffixes should be removed.
   # this also introduces an implicit filter on metric family names
-  name: 
+  name:
     # we use the value of the capture group implicitly as the API name
     # we could also explicitly write `as: "$1"`
     matches: "^container_(.*)_seconds_total$"
@@ -27,19 +27,19 @@ rules:
   # This is a Go template where the `.Series` and `.LabelMatchers` string values
   # are available, and the delimiters are `<<` and `>>` to avoid conflicts with
   # the prometheus query language
-  metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}[2m])) by (<<.GroupBy>>)"
+  metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)"
 
 # this rule matches cumulative cAdvisor metrics not measured in seconds
-- seriesQuery: '{__name__=~"^container_.*_total",container_name!="POD",namespace!="",pod_name!=""}'
+- seriesQuery: '{__name__=~"^container_.*_total",container!="POD",namespace!="",pod!=""}'
   resources:
     overrides:
       namespace: {resource: "namespace"},
-      pod_name: {resource: "pod"},
+      pod: {resource: "pod"},
   seriesFilters:
   # since this is a superset of the query above, we introduce an additional filter here
   - isNot: "^container_.*_seconds_total$"
   name: {matches: "^container_(.*)_total$"}
-  metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}[2m])) by (<<.GroupBy>>)"
+  metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)"
 
 # this rule matches cumulative non-cAdvisor metrics
 - seriesQuery: '{namespace!="",__name__!="^container_.*"}'
@@ -52,7 +52,7 @@ rules:
     # Group will be converted to a form acceptible for use as a label automatically.
     template: "<<.Resource>>"
     # if we wanted to, we could also specify overrides here
-  metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}[2m])) by (<<.GroupBy>>)"
+  metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)"
 
 # this rule matches only a single metric, explicitly naming it something else
 # It's series query *must* return only a single metric family

--- a/pkg/custom-provider/provider_test.go
+++ b/pkg/custom-provider/provider_test.go
@@ -45,13 +45,13 @@ func setupPrometheusProvider() (provider.CustomMetricsProvider, *fakeprom.FakePr
 
 	prov, _ := NewPrometheusProvider(restMapper(), fakeKubeClient, fakeProm, namers, fakeProviderUpdateInterval, fakeProviderStartDuration)
 
-	containerSel := prom.MatchSeries("", prom.NameMatches("^container_.*"), prom.LabelNeq("container_name", "POD"), prom.LabelNeq("namespace", ""), prom.LabelNeq("pod_name", ""))
+	containerSel := prom.MatchSeries("", prom.NameMatches("^container_.*"), prom.LabelNeq("container", "POD"), prom.LabelNeq("namespace", ""), prom.LabelNeq("pod", ""))
 	namespacedSel := prom.MatchSeries("", prom.LabelNeq("namespace", ""), prom.NameNotMatches("^container_.*"))
 	fakeProm.SeriesResults = map[prom.Selector][]prom.Series{
 		containerSel: {
 			{
 				Name:   "container_some_usage",
-				Labels: pmodel.LabelSet{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
+				Labels: pmodel.LabelSet{"pod": "somepod", "namespace": "somens", "container": "somecont"},
 			},
 		},
 		namespacedSel: {

--- a/pkg/custom-provider/series_registry_test.go
+++ b/pkg/custom-provider/series_registry_test.go
@@ -65,19 +65,19 @@ var seriesRegistryTestSeries = [][]prom.Series{
 	{
 		{
 			Name:   "container_some_time_seconds_total",
-			Labels: pmodel.LabelSet{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
+			Labels: pmodel.LabelSet{"pod": "somepod", "namespace": "somens", "container": "somecont"},
 		},
 	},
 	{
 		{
 			Name:   "container_some_count_total",
-			Labels: pmodel.LabelSet{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
+			Labels: pmodel.LabelSet{"pod": "somepod", "namespace": "somens", "container": "somecont"},
 		},
 	},
 	{
 		{
 			Name:   "container_some_usage",
-			Labels: pmodel.LabelSet{"pod_name": "somepod", "namespace": "somens", "container_name": "somecont"},
+			Labels: pmodel.LabelSet{"pod": "somepod", "namespace": "somens", "container": "somecont"},
 		},
 	},
 	{
@@ -161,7 +161,7 @@ var _ = Describe("Series Registry", func() {
 				resourceNames:  []string{"somepod1", "somepod2"},
 				metricSelector: labels.Everything(),
 
-				expectedQuery: "sum(container_some_usage{namespace=\"somens\",pod_name=~\"somepod1|somepod2\",container_name!=\"POD\"}) by (pod_name)",
+				expectedQuery: "sum(container_some_usage{namespace=\"somens\",pod=~\"somepod1|somepod2\",container!=\"POD\"}) by (pod)",
 			},
 			{
 				title:          "container metrics counter",
@@ -170,7 +170,7 @@ var _ = Describe("Series Registry", func() {
 				resourceNames:  []string{"somepod1", "somepod2"},
 				metricSelector: labels.Everything(),
 
-				expectedQuery: "sum(rate(container_some_count_total{namespace=\"somens\",pod_name=~\"somepod1|somepod2\",container_name!=\"POD\"}[1m])) by (pod_name)",
+				expectedQuery: "sum(rate(container_some_count_total{namespace=\"somens\",pod=~\"somepod1|somepod2\",container!=\"POD\"}[1m])) by (pod)",
 			},
 			{
 				title:          "container metrics seconds counter",
@@ -179,7 +179,7 @@ var _ = Describe("Series Registry", func() {
 				resourceNames:  []string{"somepod1", "somepod2"},
 				metricSelector: labels.Everything(),
 
-				expectedQuery: "sum(rate(container_some_time_seconds_total{namespace=\"somens\",pod_name=~\"somepod1|somepod2\",container_name!=\"POD\"}[1m])) by (pod_name)",
+				expectedQuery: "sum(rate(container_some_time_seconds_total{namespace=\"somens\",pod=~\"somepod1|somepod2\",container!=\"POD\"}[1m])) by (pod)",
 			},
 			// namespaced metrics
 			{

--- a/pkg/resourceprovider/provider_test.go
+++ b/pkg/resourceprovider/provider_test.go
@@ -49,9 +49,9 @@ func restMapper() apimeta.RESTMapper {
 func buildPodSample(namespace, pod, container string, val float64, ts int64) *pmodel.Sample {
 	return &pmodel.Sample{
 		Metric: pmodel.Metric{
-			"namespace":      pmodel.LabelValue(namespace),
-			"pod_name":       pmodel.LabelValue(pod),
-			"container_name": pmodel.LabelValue(container),
+			"namespace": pmodel.LabelValue(namespace),
+			"pod":       pmodel.LabelValue(pod),
+			"container": pmodel.LabelValue(container),
 		},
 		Value:     pmodel.SampleValue(val),
 		Timestamp: pmodel.Time(ts),


### PR DESCRIPTION
This was brought up in https://github.com/kubernetes-sigs/prometheus-adapter/issues/289. The metric labels are incorrect for Kubernetes 1.16+, because the labels were [removed](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#removed-metrics).