### PR TITLE
Move prometheus-adapter to sigs.k8s.io golang package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ all: $(OUT_DIR)/$(ARCH)/adapter
 
 src_deps=$(shell find pkg cmd -type f -name "*.go")
 $(OUT_DIR)/%/adapter: $(src_deps)
-	CGO_ENABLED=0 GOARCH=$* go build -tags netgo -o $(OUT_DIR)/$*/adapter github.com/kubernetes-sigs/prometheus-adapter/cmd/adapter
+	CGO_ENABLED=0 GOARCH=$* go build -tags netgo -o $(OUT_DIR)/$*/adapter sigs.k8s.io/prometheus-adapter/cmd/adapter
 
 docker-build: $(OUT_DIR)/Dockerfile
-	docker run -it -v $(OUT_DIR):/build -v $(PWD):/go/src/github.com/kubernetes-sigs/prometheus-adapter -e GOARCH=$(ARCH) $(GOIMAGE) /bin/bash -c "\
-		CGO_ENABLED=0 go build -tags netgo -o /build/$(ARCH)/adapter github.com/kubernetes-sigs/prometheus-adapter/cmd/adapter"
+	docker run -it -v $(OUT_DIR):/build -v $(PWD):/go/src/sigs.k8s.io/prometheus-adapter -e GOARCH=$(ARCH) $(GOIMAGE) /bin/bash -c "\
+		CGO_ENABLED=0 go build -tags netgo -o /build/$(ARCH)/adapter sigs.k8s.io/prometheus-adapter/cmd/adapter"
 
 	docker build -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(VERSION) --build-arg ARCH=$(ARCH) --build-arg BASEIMAGE=$(BASEIMAGE) $(OUT_DIR)
 

--- a/cmd/adapter/adapter.go
+++ b/cmd/adapter/adapter.go
@@ -27,6 +27,9 @@ import (
 	"os"
 	"time"
 
+	basecmd "github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/cmd"
+	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
+
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/rest"
@@ -36,18 +39,16 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/sample-apiserver/pkg/apiserver"
 
-	basecmd "github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/cmd"
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
 	"sigs.k8s.io/metrics-server/pkg/api"
 
-	generatedopenapi "github.com/kubernetes-sigs/prometheus-adapter/pkg/api/generated/openapi"
-	prom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
-	mprom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client/metrics"
-	adaptercfg "github.com/kubernetes-sigs/prometheus-adapter/pkg/config"
-	cmprov "github.com/kubernetes-sigs/prometheus-adapter/pkg/custom-provider"
-	extprov "github.com/kubernetes-sigs/prometheus-adapter/pkg/external-provider"
-	"github.com/kubernetes-sigs/prometheus-adapter/pkg/naming"
-	resprov "github.com/kubernetes-sigs/prometheus-adapter/pkg/resourceprovider"
+	generatedopenapi "sigs.k8s.io/prometheus-adapter/pkg/api/generated/openapi"
+	prom "sigs.k8s.io/prometheus-adapter/pkg/client"
+	mprom "sigs.k8s.io/prometheus-adapter/pkg/client/metrics"
+	adaptercfg "sigs.k8s.io/prometheus-adapter/pkg/config"
+	cmprov "sigs.k8s.io/prometheus-adapter/pkg/custom-provider"
+	extprov "sigs.k8s.io/prometheus-adapter/pkg/external-provider"
+	"sigs.k8s.io/prometheus-adapter/pkg/naming"
+	resprov "sigs.k8s.io/prometheus-adapter/pkg/resourceprovider"
 )
 
 type PrometheusAdapter struct {

--- a/cmd/config-gen/main.go
+++ b/cmd/config-gen/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/kubernetes-sigs/prometheus-adapter/cmd/config-gen/utils"
+	"sigs.k8s.io/prometheus-adapter/cmd/config-gen/utils"
 )
 
 func main() {

--- a/cmd/config-gen/utils/default.go
+++ b/cmd/config-gen/utils/default.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	prom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
-	. "github.com/kubernetes-sigs/prometheus-adapter/pkg/config"
 	pmodel "github.com/prometheus/common/model"
+
+	prom "sigs.k8s.io/prometheus-adapter/pkg/client"
+	. "sigs.k8s.io/prometheus-adapter/pkg/config"
 )
 
 // DefaultConfig returns a configuration equivalent to the former

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kubernetes-sigs/prometheus-adapter
+module sigs.k8s.io/prometheus-adapter
 
 go 1.16
 

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"fmt"
 
-	prom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
 	pmodel "github.com/prometheus/common/model"
+
+	prom "sigs.k8s.io/prometheus-adapter/pkg/client"
 )
 
 // FakePrometheusClient is a fake instance of prom.Client

--- a/pkg/client/metrics/metrics.go
+++ b/pkg/client/metrics/metrics.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
+	"sigs.k8s.io/prometheus-adapter/pkg/client"
 )
 
 var (

--- a/pkg/custom-provider/provider.go
+++ b/pkg/custom-provider/provider.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
 	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider/helpers"
 	pmodel "github.com/prometheus/common/model"
+
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -37,8 +38,8 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/metrics/pkg/apis/custom_metrics"
 
-	prom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
-	"github.com/kubernetes-sigs/prometheus-adapter/pkg/naming"
+	prom "sigs.k8s.io/prometheus-adapter/pkg/client"
+	"sigs.k8s.io/prometheus-adapter/pkg/naming"
 )
 
 // Runnable represents something that can be run until told to stop.

--- a/pkg/custom-provider/provider_test.go
+++ b/pkg/custom-provider/provider_test.go
@@ -19,16 +19,17 @@ package provider
 import (
 	"time"
 
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	fakedyn "k8s.io/client-go/dynamic/fake"
 
-	config "github.com/kubernetes-sigs/prometheus-adapter/cmd/config-gen/utils"
-	prom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
-	fakeprom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client/fake"
-	"github.com/kubernetes-sigs/prometheus-adapter/pkg/naming"
+	config "sigs.k8s.io/prometheus-adapter/cmd/config-gen/utils"
+	prom "sigs.k8s.io/prometheus-adapter/pkg/client"
+	fakeprom "sigs.k8s.io/prometheus-adapter/pkg/client/fake"
+	"sigs.k8s.io/prometheus-adapter/pkg/naming"
+
+	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	pmodel "github.com/prometheus/common/model"
 )
 

--- a/pkg/custom-provider/series_registry.go
+++ b/pkg/custom-provider/series_registry.go
@@ -20,14 +20,15 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
-
-	prom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
-	"github.com/kubernetes-sigs/prometheus-adapter/pkg/naming"
-	pmodel "github.com/prometheus/common/model"
 	"k8s.io/klog/v2"
+
+	prom "sigs.k8s.io/prometheus-adapter/pkg/client"
+	"sigs.k8s.io/prometheus-adapter/pkg/naming"
+
+	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
+	pmodel "github.com/prometheus/common/model"
 )
 
 // NB: container metrics sourced from cAdvisor don't consistently follow naming conventions,

--- a/pkg/custom-provider/series_registry_test.go
+++ b/pkg/custom-provider/series_registry_test.go
@@ -31,9 +31,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 
-	config "github.com/kubernetes-sigs/prometheus-adapter/cmd/config-gen/utils"
-	prom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
-	"github.com/kubernetes-sigs/prometheus-adapter/pkg/naming"
+	config "sigs.k8s.io/prometheus-adapter/cmd/config-gen/utils"
+	prom "sigs.k8s.io/prometheus-adapter/pkg/client"
+	"sigs.k8s.io/prometheus-adapter/pkg/naming"
 )
 
 // restMapper creates a RESTMapper with just the types we need for

--- a/pkg/external-provider/basic_metric_lister.go
+++ b/pkg/external-provider/basic_metric_lister.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"time"
 
-	pmodel "github.com/prometheus/common/model"
 	"k8s.io/klog/v2"
 
-	prom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
-	"github.com/kubernetes-sigs/prometheus-adapter/pkg/naming"
+	prom "sigs.k8s.io/prometheus-adapter/pkg/client"
+	"sigs.k8s.io/prometheus-adapter/pkg/naming"
+
+	pmodel "github.com/prometheus/common/model"
 )
 
 // Runnable represents something that can be run until told to stop.

--- a/pkg/external-provider/external_series_registry.go
+++ b/pkg/external-provider/external_series_registry.go
@@ -20,8 +20,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
 
-	prom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
-	"github.com/kubernetes-sigs/prometheus-adapter/pkg/naming"
+	prom "sigs.k8s.io/prometheus-adapter/pkg/client"
+	"sigs.k8s.io/prometheus-adapter/pkg/naming"
 )
 
 // ExternalSeriesRegistry acts as the top-level converter for transforming Kubernetes requests

--- a/pkg/external-provider/metric_converter.go
+++ b/pkg/external-provider/metric_converter.go
@@ -17,12 +17,14 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
-	prom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
-	"github.com/prometheus/common/model"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/metrics/pkg/apis/external_metrics"
+
+	prom "sigs.k8s.io/prometheus-adapter/pkg/client"
+
+	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
+	"github.com/prometheus/common/model"
 )
 
 // MetricConverter provides a unified interface for converting the results of

--- a/pkg/external-provider/periodic_metric_lister_test.go
+++ b/pkg/external-provider/periodic_metric_lister_test.go
@@ -17,7 +17,8 @@ import (
 	"testing"
 	"time"
 
-	prom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
+	prom "sigs.k8s.io/prometheus-adapter/pkg/client"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/external-provider/provider.go
+++ b/pkg/external-provider/provider.go
@@ -29,8 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
-	prom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
-	"github.com/kubernetes-sigs/prometheus-adapter/pkg/naming"
+	prom "sigs.k8s.io/prometheus-adapter/pkg/client"
+	"sigs.k8s.io/prometheus-adapter/pkg/naming"
 )
 
 type externalPrometheusProvider struct {

--- a/pkg/naming/metric_namer.go
+++ b/pkg/naming/metric_namer.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	prom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
-	"github.com/kubernetes-sigs/prometheus-adapter/pkg/config"
+	prom "sigs.k8s.io/prometheus-adapter/pkg/client"
+	"sigs.k8s.io/prometheus-adapter/pkg/config"
 )
 
 // MetricNamer knows how to convert Prometheus series names and label names to

--- a/pkg/naming/metrics_query.go
+++ b/pkg/naming/metrics_query.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 
-	prom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
+	prom "sigs.k8s.io/prometheus-adapter/pkg/client"
 )
 
 // MetricsQuery represents a compiled metrics query for some set of

--- a/pkg/naming/metrics_query_test.go
+++ b/pkg/naming/metrics_query_test.go
@@ -20,11 +20,13 @@ import (
 	"fmt"
 	"testing"
 
-	prom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
-	pmodel "github.com/prometheus/common/model"
 	labels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
+
+	prom "sigs.k8s.io/prometheus-adapter/pkg/client"
+
+	pmodel "github.com/prometheus/common/model"
 )
 
 type resourceConverterMock struct {

--- a/pkg/naming/regex_matcher_test.go
+++ b/pkg/naming/regex_matcher_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/kubernetes-sigs/prometheus-adapter/pkg/config"
+	"sigs.k8s.io/prometheus-adapter/pkg/config"
 )
 
 func TestReMatcherIs(t *testing.T) {

--- a/pkg/naming/resource_converter.go
+++ b/pkg/naming/resource_converter.go
@@ -25,12 +25,13 @@ import (
 
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+
+	prom "sigs.k8s.io/prometheus-adapter/pkg/client"
+	"sigs.k8s.io/prometheus-adapter/pkg/config"
 
 	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
-	prom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
-	"github.com/kubernetes-sigs/prometheus-adapter/pkg/config"
 	pmodel "github.com/prometheus/common/model"
-	"k8s.io/klog/v2"
 )
 
 var (

--- a/pkg/resourceprovider/provider.go
+++ b/pkg/resourceprovider/provider.go
@@ -30,11 +30,13 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	metrics "k8s.io/metrics/pkg/apis/metrics"
+
 	"sigs.k8s.io/metrics-server/pkg/api"
 
-	"github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
-	"github.com/kubernetes-sigs/prometheus-adapter/pkg/config"
-	"github.com/kubernetes-sigs/prometheus-adapter/pkg/naming"
+	"sigs.k8s.io/prometheus-adapter/pkg/client"
+	"sigs.k8s.io/prometheus-adapter/pkg/config"
+	"sigs.k8s.io/prometheus-adapter/pkg/naming"
+
 	pmodel "github.com/prometheus/common/model"
 )
 

--- a/pkg/resourceprovider/provider_test.go
+++ b/pkg/resourceprovider/provider_test.go
@@ -19,8 +19,6 @@ package resourceprovider
 import (
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -28,11 +26,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/metrics/pkg/apis/metrics"
+
 	"sigs.k8s.io/metrics-server/pkg/api"
 
-	config "github.com/kubernetes-sigs/prometheus-adapter/cmd/config-gen/utils"
-	prom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client"
-	fakeprom "github.com/kubernetes-sigs/prometheus-adapter/pkg/client/fake"
+	config "sigs.k8s.io/prometheus-adapter/cmd/config-gen/utils"
+	prom "sigs.k8s.io/prometheus-adapter/pkg/client"
+	fakeprom "sigs.k8s.io/prometheus-adapter/pkg/client/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	pmodel "github.com/prometheus/common/model"
 )
 


### PR DESCRIPTION
With the move to the kubernetes-sigs organization, we renamed the go module to `github.com/kubernetes-sigs/prometheus-adapter` instead of `sigs.k8s.io/prometheus-adapter` like most of the projects in the org.

So this PR:
- Rename the go module to sigs.k8s.io/prometheus-adapter
- Reorder imports with goimports