### PR TITLE
Improve container push rules

### DIFF
--- a/.travis-deploy.sh
+++ b/.travis-deploy.sh
@@ -3,7 +3,7 @@ set -x
 docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
 
 if [[ -n $TRAVIS_TAG ]]; then
-    make push TAG="$(cat "VERSION")"
+    make push
 else
-    make push-amd64
+    TAG=latest make push
 fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-ARG BASEIMAGE
-ARG GOIMAGE
+ARG GO_VERSION
 
-FROM ${GOIMAGE} as build
+FROM golang:${GO_VERSION} as build
 
 WORKDIR /go/src/sigs.k8s.io/prometheus-adapter
 COPY go.mod .
@@ -15,7 +14,7 @@ COPY Makefile Makefile
 ARG ARCH
 RUN make prometheus-adapter
 
-FROM ${BASEIMAGE}
+FROM gcr.io/distroless/static:latest
 
 COPY --from=build /go/src/sigs.k8s.io/prometheus-adapter/adapter /
 USER 65534


### PR DESCRIPTION
Improve and cleanup container push rules to prepare for the move to the
official gcr.k8s.io registry.
As part of the improvements, I replaced the non-cross-platform busybox
image by gcr.io/distroless/static:latest which is platform agnostic.