### PR TITLE
Default images to the official k8s.gcr.io and gcr.io registries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-REGISTRY?=directxman12
-IMAGE?=k8s-prometheus-adapter
+REGISTRY?=gcr.io/k8s-staging-prometheus-adapter
+IMAGE?=prometheus-adapter
 ARCH?=$(shell go env GOARCH)
 ALL_ARCH=amd64 arm arm64 ppc64le s390x
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,7 +1,7 @@
 Example Deployment
 ==================
 
-1. Make sure you've built the included Dockerfile with `make docker-build`. The image should be tagged as `directxman12/k8s-prometheus-adapter:latest`.
+1. Make sure you've built the included Dockerfile with `TAG=latest make container`. The image should be tagged as `gcr.io/k8s-staging-prometheus-adapter:latest`.
 
 2. Create a secret called `cm-adapter-serving-certs` with two values:
    `serving.crt` and `serving.key`. These are the serving certificates used

--- a/deploy/manifests/custom-metrics-apiserver-deployment.yaml
+++ b/deploy/manifests/custom-metrics-apiserver-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: custom-metrics-apiserver
-        image: directxman12/k8s-prometheus-adapter-amd64
+        image: gcr.io/k8s-staging-prometheus-adapter-amd64
         args:
         - --secure-port=6443
         - --tls-cert-file=/var/run/serving-cert/serving.crt

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -41,12 +41,16 @@ instead, you'll need to make a few adjustments to the way you expose
 metrics to Prometheus.
 
 The adapter has different images for each arch, which can be found at
-`directxman12/k8s-prometheus-adapter-${ARCH}`. For instance, if you're on
-an x86_64 machine, use the `directxman12/k8s-prometheus-adapter-amd64`
-image.
+`gcr.io/k8s-staging-prometheus-adapter/prometheus-adapter-${ARCH}`. For
+instance, if you're on an x86_64 machine, use
+`gcr.io/k8s-staging-prometheus-adapter/prometheus-adapter-amd64` image.
 
-If you're feeling adventurous, you can build the latest version of the
-custom metrics adapter by running `make docker-build`.
+There is also an official multi arch image available at
+`k8s.gcr.io/prometheus-adapter/prometheus-adapter:${VERSION}`.
+
+If you're feeling adventurous, you can build the latest version of
+prometheus-adapter by running `make container` or get the latest image from the
+staging registry `gcr.io/k8s-staging-prometheus-adapter/prometheus-adapter`.
 
 Special thanks to [@luxas](https://github.com/luxas) for providing the
 demo application for this walkthrough.


### PR DESCRIPTION
Default to the official gcr registries `k8s.gcr.io/prometheus-adapter` and `gcr.io/k8s-staging-prometheus-adapter` instead of https://hub.docker.com/r/directxman12/k8s-prometheus-adapter and https://quay.io/repository/coreos/k8s-prometheus-adapter-amd64.

Ref: https://github.com/kubernetes-sigs/prometheus-adapter/issues/414