### PR TITLE
Stop populating IMAGE env variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REGISTRY?=gcr.io/k8s-staging-prometheus-adapter
-IMAGE?=prometheus-adapter
+IMAGE=prometheus-adapter
 ARCH?=$(shell go env GOARCH)
 ALL_ARCH=amd64 arm arm64 ppc64le s390x
 


### PR DESCRIPTION
The IMAGE env variable is used by prow when building images, so it was
replacing what we would have expected to be the `prometheus-adapter`
image by the container image used to build the prometheus-adapter image.

Ref to the deploy failures highlighting this issue on master: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-prometheus-adapter-push-images/1410561345820037120