### PR TITLE
Increase cloudbuild timeout to 1h

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config                                            
-timeout: 1800s
+timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
 steps:


### PR DESCRIPTION
As per recent [CI run](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-prometheus-adapter-push-images/1412400508353646592), the current timeout of 30 minutes might be too low since it takes ~25 minutes to build all images and push them to the gcr registry.

cc @fpetkovski