### PR TITLE
README: improve gcr.k8s.io instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ helm install --name my-release prometheus-community/prometheus-adapter
 
 Official images
 ---
-All official images for releases after v0.8.4 are available in [gcr.io](http://k8s.gcr.io/prometheus-adapter/prometheus-adapter). The project also maintains a [staging registry](https://console.cloud.google.com/gcr/images/k8s-staging-prometheus-adapter/GLOBAL/) where images for each commit from the master branch are published. You can use this registry if you need to test a version from a specific commit, or if you need to deploy a patch while waiting for a new release.
+All official images for releases after v0.8.4 are available in `k8s.gcr.io/prometheus-adapter/prometheus-adapter:$VERSION`. The project also maintains a [staging registry](https://console.cloud.google.com/gcr/images/k8s-staging-prometheus-adapter/GLOBAL/) where images for each commit from the master branch are published. You can use this registry if you need to test a version from a specific commit, or if you need to deploy a patch while waiting for a new release.
 
 Images for versions v0.8.4 and prior are only available in unofficial registries:
 * https://quay.io/repository/coreos/k8s-prometheus-adapter-amd64


### PR DESCRIPTION
Images hosted on gcr.k8s.io aren't browsable to the users, so linking to
the website results in a 403 HTTP error which is confusing.