### PR TITLE
Update walkthrough.md (fix selector)

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -175,7 +175,7 @@ spec:
 If you try creating that now (and take a look at your controller-manager
 logs), you'll see that the that the HorizontalPodAutoscaler controller is
 attempting to fetch metrics from
-`/apis/custom.metrics.k8s.io/v1beta1/namespaces/default/pods/*/http_requests?selector=app%3Dsample-app`,
+`/apis/custom.metrics.k8s.io/v1beta1/namespaces/default/pods/*/http_requests?metricLabelSelector=app%3Dsample-app`,
 but right now, nothing's serving that API.
 
 Before you can autoscale your application, you'll need to make sure that
@@ -293,7 +293,7 @@ sends a raw GET request to the Kubernetes API server, automatically
 injecting auth information:
 
 ```shell
-$ kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta1/namespaces/default/pods/*/http_requests?selector=app%3Dsample-app"
+$ kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta1/namespaces/default/pods/*/http_requests?metricLabelSelector=app%3Dsample-app"
 ```
 
 Because of the adapter's configuration, the cumulative metric


### PR DESCRIPTION
selecting label with `metricLabelSelector` and not `selector` while calling the API
cf. https://github.com/kubernetes-sigs/custom-metrics-apiserver/blob/0ca2b1909cdc45259654a4e06cac40f98fa1bcb0/pkg/apiserver/installer/conversion.go#L36