### PR TITLE
fix: add support for maxAge in external provider

### DIFF
--- a/cmd/adapter/adapter.go
+++ b/cmd/adapter/adapter.go
@@ -211,7 +211,7 @@ func (cmd *PrometheusAdapter) makeExternalProvider(promClient prom.Client, stopC
 	}
 
 	// construct the provider and start it
-	emProvider, runner := extprov.NewExternalPrometheusProvider(promClient, namers, cmd.MetricsRelistInterval)
+	emProvider, runner := extprov.NewExternalPrometheusProvider(promClient, namers, cmd.MetricsRelistInterval, cmd.MetricsMaxAge)
 	runner.RunUntil(stopCh)
 
 	return emProvider, nil

--- a/pkg/external-provider/provider.go
+++ b/pkg/external-provider/provider.go
@@ -77,9 +77,9 @@ func (p *externalPrometheusProvider) selectGroupResource(namespace string) schem
 }
 
 // NewExternalPrometheusProvider creates an ExternalMetricsProvider capable of responding to Kubernetes requests for external metric data
-func NewExternalPrometheusProvider(promClient prom.Client, namers []naming.MetricNamer, updateInterval time.Duration) (provider.ExternalMetricsProvider, Runnable) {
+func NewExternalPrometheusProvider(promClient prom.Client, namers []naming.MetricNamer, updateInterval time.Duration, maxAge time.Duration) (provider.ExternalMetricsProvider, Runnable) {
 	metricConverter := NewMetricConverter()
-	basicLister := NewBasicMetricLister(promClient, namers, updateInterval)
+	basicLister := NewBasicMetricLister(promClient, namers, maxAge)
 	periodicLister, _ := NewPeriodicMetricLister(basicLister, updateInterval)
 	seriesRegistry := NewExternalSeriesRegistry(periodicLister)
 	return &externalPrometheusProvider{


### PR DESCRIPTION
Hello,

Not sure if this is correct but the `--maxAge` flag is no taken into account for the `external` metrics provider.