### PR TITLE
Fix external metrics provider not respecting metrics-max-age

### DIFF
--- a/cmd/adapter/adapter.go
+++ b/cmd/adapter/adapter.go
@@ -211,7 +211,7 @@ func (cmd *PrometheusAdapter) makeExternalProvider(promClient prom.Client, stopC
 	}
 
 	// construct the provider and start it
-	emProvider, runner := extprov.NewExternalPrometheusProvider(promClient, namers, cmd.MetricsRelistInterval)
+	emProvider, runner := extprov.NewExternalPrometheusProvider(promClient, namers, cmd.MetricsRelistInterval, cmd.MetricsMaxAge)
 	runner.RunUntil(stopCh)
 
 	return emProvider, nil

--- a/pkg/external-provider/provider.go
+++ b/pkg/external-provider/provider.go
@@ -77,9 +77,9 @@ func (p *externalPrometheusProvider) selectGroupResource(namespace string) schem
 }
 
 // NewExternalPrometheusProvider creates an ExternalMetricsProvider capable of responding to Kubernetes requests for external metric data
-func NewExternalPrometheusProvider(promClient prom.Client, namers []naming.MetricNamer, updateInterval time.Duration) (provider.ExternalMetricsProvider, Runnable) {
+func NewExternalPrometheusProvider(promClient prom.Client, namers []naming.MetricNamer, updateInterval time.Duration, maxAge time.Duration) (provider.ExternalMetricsProvider, Runnable) {
 	metricConverter := NewMetricConverter()
-	basicLister := NewBasicMetricLister(promClient, namers, updateInterval)
+	basicLister := NewBasicMetricLister(promClient, namers, maxAge)
 	periodicLister, _ := NewPeriodicMetricLister(basicLister, updateInterval)
 	seriesRegistry := NewExternalSeriesRegistry(periodicLister)
 	return &externalPrometheusProvider{


### PR DESCRIPTION
Refer to conversation in https://github.com/kubernetes-sigs/prometheus-adapter/pull/455#issuecomment-940745397

> This PR fixes an issue for External Metrics where the `--metrics-max-age` setting is not respected.

> For my particular use case, currently I'm running into a problem where metrics are sometimes disappearing because the metric we're using has a 2 minutes delay when fetched. So if we fetch metrics using the relist interval (i.e. < 2 minutes), there's a chance that we would not see the metrics.

> This problem we encountered similarly for custom metrics was resolved by maintaining relist-interval at 1 minute, and increasing `--metrics-max-age` to 5 minutes. It has been working perfectly fine since then, but now we're introducing another metric similar to that but as an external metric, and we starts to see the issue for external metrics.