### PR TITLE
Drop unused alias in OWNERS_ALIASES

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,7 +8,6 @@ approvers:
 
 reviewers:
   - prometheus-adapter-approvers
-  - prometheus-adapter-reviewers
 
 emeritus_approvers:
 - brancz

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,4 +4,3 @@ aliases:
   prometheus-adapter-approvers:
   - dgrisonnet
   - s-urbaniak
-  prometheus-adapter-reviewers: []


### PR DESCRIPTION
Trips up some python based tools. Could we remove this since it is not being used?

Signed-off-by: Davanum Srinivas <davanum@gmail.com>