### PR TITLE
Set non zero query parameter for end in series query API

### DIFF
--- a/pkg/custom-provider/provider.go
+++ b/pkg/custom-provider/provider.go
@@ -238,7 +238,7 @@ type selectorSeries struct {
 
 func (l *cachingMetricsLister) updateMetrics() error {
 	startTime := pmodel.Now().Add(-1 * l.maxAge)
-
+	endTime := pmodel.Now()
 	// don't do duplicate queries when it's just the matchers that change
 	seriesCacheByQuery := make(map[prom.Selector][]prom.Series)
 
@@ -256,7 +256,7 @@ func (l *cachingMetricsLister) updateMetrics() error {
 		}
 		selectors[sel] = struct{}{}
 		go func() {
-			series, err := l.promClient.Series(context.TODO(), pmodel.Interval{startTime, 0}, sel)
+			series, err := l.promClient.Series(context.TODO(), pmodel.Interval{Start: startTime, End: endTime}, sel)
 			if err != nil {
 				errs <- fmt.Errorf("unable to fetch metrics for query %q: %v", sel, err)
 				return

--- a/pkg/external-provider/basic_metric_lister.go
+++ b/pkg/external-provider/basic_metric_lister.go
@@ -85,7 +85,7 @@ func (l *basicMetricLister) ListAllMetrics() (MetricUpdateResult, error) {
 	}
 
 	startTime := pmodel.Now().Add(-1 * l.lookback)
-
+	endTime := pmodel.Now()
 	// these can take a while on large clusters, so launch in parallel
 	// and don't duplicate
 	selectors := make(map[prom.Selector]struct{})
@@ -100,7 +100,7 @@ func (l *basicMetricLister) ListAllMetrics() (MetricUpdateResult, error) {
 		}
 		selectors[sel] = struct{}{}
 		go func() {
-			series, err := l.promClient.Series(context.TODO(), pmodel.Interval{startTime, 0}, sel)
+			series, err := l.promClient.Series(context.TODO(), pmodel.Interval{Start: startTime, End: endTime}, sel)
 			if err != nil {
 				errs <- fmt.Errorf("unable to fetch metrics for query %q: %v", sel, err)
 				return


### PR DESCRIPTION
**Current behavior**
* When we query for series metric, we pass zero as value for end query key.
Ex : http://localhost:9090/api/v1/series?match[]=my_metric&start=1651129852&end=0'
* The error is similar to [this](https://github.com/prometheus/prometheus/issues/4197).
* While this works on self hosted prometheus, I faced an issue where seriesQuery started throwing error on managed prometheus provided by GCP.
* It worked after I started using custom build passing valid end time.