### PR TITLE
Add --prometheus-verb to support POST requests to prometheus servers

### DIFF
--- a/cmd/adapter/adapter.go
+++ b/cmd/adapter/adapter.go
@@ -93,7 +93,7 @@ func (cmd *PrometheusAdapter) makePromClient() (prom.Client, error) {
 	}
 
 	if cmd.PrometheusVerb != http.MethodGet && cmd.PrometheusVerb != http.MethodPost {
-		return nil, fmt.Errorf("unsupported Prometheus Http Verb %q", cmd.PrometheusVerb)
+		return nil, fmt.Errorf("unsupported Prometheus HTTP verb %q. use \"GET\" or \"POST\" instead.", cmd.PrometheusVerb)
 	}
 
 	var httpClient *http.Client
@@ -144,7 +144,7 @@ func (cmd *PrometheusAdapter) addFlags() {
 	cmd.Flags().StringArrayVar(&cmd.PrometheusHeaders, "prometheus-header", cmd.PrometheusHeaders,
 		"Optional header to set on requests to prometheus-url. Can be repeated")
 	cmd.Flags().StringVar(&cmd.PrometheusVerb, "prometheus-verb", cmd.PrometheusVerb,
-		"HTTP Verb to set on requests to Prometheus.")
+		"HTTP verb to set on requests to Prometheus. Possible values: \"GET\", \"POST\"")
 	cmd.Flags().StringVar(&cmd.AdapterConfigFile, "config", cmd.AdapterConfigFile,
 		"Configuration file containing details of how to transform between Prometheus metrics "+
 			"and custom metrics API resources")

--- a/cmd/adapter/adapter.go
+++ b/cmd/adapter/adapter.go
@@ -74,6 +74,8 @@ type PrometheusAdapter struct {
 	PrometheusTokenFile string
 	// PrometheusHeaders is a k=v list of headers to set on requests to PrometheusURL
 	PrometheusHeaders []string
+	// PrometheusVerb is a verb to set on requests to PrometheusURL
+	PrometheusVerb string
 	// AdapterConfigFile points to the file containing the metrics discovery configuration.
 	AdapterConfigFile string
 	// MetricsRelistInterval is the interval at which to relist the set of available metrics
@@ -88,6 +90,10 @@ func (cmd *PrometheusAdapter) makePromClient() (prom.Client, error) {
 	baseURL, err := url.Parse(cmd.PrometheusURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Prometheus URL %q: %v", baseURL, err)
+	}
+
+	if cmd.PrometheusVerb != http.MethodGet && cmd.PrometheusVerb != http.MethodPost {
+		return nil, fmt.Errorf("unsupported Prometheus Http Verb %q", cmd.PrometheusVerb)
 	}
 
 	var httpClient *http.Client
@@ -117,7 +123,7 @@ func (cmd *PrometheusAdapter) makePromClient() (prom.Client, error) {
 	}
 	genericPromClient := prom.NewGenericAPIClient(httpClient, baseURL, parseHeaderArgs(cmd.PrometheusHeaders))
 	instrumentedGenericPromClient := mprom.InstrumentGenericAPIClient(genericPromClient, baseURL.String())
-	return prom.NewClientForAPI(instrumentedGenericPromClient), nil
+	return prom.NewClientForAPI(instrumentedGenericPromClient, cmd.PrometheusVerb), nil
 }
 
 func (cmd *PrometheusAdapter) addFlags() {
@@ -137,6 +143,8 @@ func (cmd *PrometheusAdapter) addFlags() {
 		"Optional file containing the bearer token to use when connecting with Prometheus")
 	cmd.Flags().StringArrayVar(&cmd.PrometheusHeaders, "prometheus-header", cmd.PrometheusHeaders,
 		"Optional header to set on requests to prometheus-url. Can be repeated")
+	cmd.Flags().StringVar(&cmd.PrometheusVerb, "prometheus-verb", cmd.PrometheusVerb,
+		"HTTP Verb to set on requests to Prometheus.")
 	cmd.Flags().StringVar(&cmd.AdapterConfigFile, "config", cmd.AdapterConfigFile,
 		"Configuration file containing details of how to transform between Prometheus metrics "+
 			"and custom metrics API resources")
@@ -274,6 +282,7 @@ func main() {
 	// set up flags
 	cmd := &PrometheusAdapter{
 		PrometheusURL:         "https://localhost",
+		PrometheusVerb:        http.MethodGet,
 		MetricsRelistInterval: 10 * time.Minute,
 	}
 	cmd.Name = "prometheus-metrics-adapter"


### PR DESCRIPTION
We hit the limitation of HTTP request line size of a certain managed prometheus service. To avoid the limitation, we would like to use POST method to query Prometheus servers.

Docs: https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries

> You can URL-encode these parameters directly in the request body by using the POST method and Content-Type: application/x-www-form-urlencoded header. This is useful when specifying a large query that may breach server-side URL character limits.

