### PR TITLE
Fix image location in manifests

### DIFF
--- a/deploy/manifests/custom-metrics-apiserver-deployment.yaml
+++ b/deploy/manifests/custom-metrics-apiserver-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: custom-metrics-apiserver
-        image: gcr.io/k8s-staging-prometheus-adapter-amd64
+        image: k8s.gcr.io/prometheus-adapter/prometheus-adapter:v0.10.0
         args:
         - --secure-port=6443
         - --tls-cert-file=/var/run/serving-cert/serving.crt


### PR DESCRIPTION
Point the images to the official prometheus-adapter image in gcr.

Fixes #527