### PR TITLE
Update registry location to registry.k8s.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ helm install my-release prometheus-community/prometheus-adapter
 
 Official images
 ---
-All official images for releases after v0.8.4 are available in `k8s.gcr.io/prometheus-adapter/prometheus-adapter:$VERSION`. The project also maintains a [staging registry](https://console.cloud.google.com/gcr/images/k8s-staging-prometheus-adapter/GLOBAL/) where images for each commit from the master branch are published. You can use this registry if you need to test a version from a specific commit, or if you need to deploy a patch while waiting for a new release.
+All official images for releases after v0.8.4 are available in `registry.k8s.io/prometheus-adapter/prometheus-adapter:$VERSION`. The project also maintains a [staging registry](https://console.cloud.google.com/gcr/images/k8s-staging-prometheus-adapter/GLOBAL/) where images for each commit from the master branch are published. You can use this registry if you need to test a version from a specific commit, or if you need to deploy a patch while waiting for a new release.
 
 Images for versions v0.8.4 and prior are only available in unofficial registries:
 * https://quay.io/repository/coreos/k8s-prometheus-adapter-amd64

--- a/deploy/manifests/custom-metrics-apiserver-deployment.yaml
+++ b/deploy/manifests/custom-metrics-apiserver-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: custom-metrics-apiserver
-        image: k8s.gcr.io/prometheus-adapter/prometheus-adapter:v0.10.0
+        image: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.10.0
         args:
         - --secure-port=6443
         - --tls-cert-file=/var/run/serving-cert/serving.crt

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -46,7 +46,8 @@ instance, if you're on an x86_64 machine, use
 `gcr.io/k8s-staging-prometheus-adapter/prometheus-adapter-amd64` image.
 
 There is also an official multi arch image available at
-`k8s.gcr.io/prometheus-adapter/prometheus-adapter:${VERSION}`.
+`registry.k8s.io/prometheus-adapter/prometheus-adapter:${VERSION}`.
+
 
 If you're feeling adventurous, you can build the latest version of
 prometheus-adapter by running `make container` or get the latest image from the


### PR DESCRIPTION
Use new domain for k8s image registry, as per https://groups.google.com/a/kubernetes.io/g/dev/c/DYZYNQ_A6_c/m/FpHqeVR2BAAJ

More context: https://github.com/kubernetes/kubernetes/pull/109938