### PR TITLE
Fix segfault when using --prometheus-token-file

### DIFF
--- a/cmd/adapter/adapter.go
+++ b/cmd/adapter/adapter.go
@@ -119,7 +119,11 @@ func (cmd *PrometheusAdapter) makePromClient() (prom.Client, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read prometheus-token-file: %v", err)
 		}
-		httpClient.Transport = transport.NewBearerAuthRoundTripper(string(data), httpClient.Transport)
+		wrappedTransport := http.DefaultTransport
+		if httpClient.Transport != nil {
+			wrappedTransport = httpClient.Transport
+		}
+		httpClient.Transport = transport.NewBearerAuthRoundTripper(string(data), wrappedTransport)
 	}
 	genericPromClient := prom.NewGenericAPIClient(httpClient, baseURL, parseHeaderArgs(cmd.PrometheusHeaders))
 	instrumentedGenericPromClient := mprom.InstrumentGenericAPIClient(genericPromClient, baseURL.String())


### PR DESCRIPTION
When `--prometheus-token-file` is used, prometheus-adapter crashes with a segmentation violation error

This is caused by `httpClient.Transport` being `nil` and being dereferenced in the `BearerAuthRoundTripper`.

Fixes #478 