### PR TITLE
Set MinVersion: tls.VersionTLS12 in prometheus client's TLSClientConfig

### DIFF
--- a/cmd/adapter/adapter.go
+++ b/cmd/adapter/adapter.go
@@ -408,10 +408,10 @@ func makePrometheusCAClient(caFilePath string, tlsCertFilePath string, tlsKeyFil
 		}
 		return &http.Client{
 			Transport: &http.Transport{
-				//nolint:gosec
 				TLSClientConfig: &tls.Config{
 					RootCAs:      pool,
 					Certificates: []tls.Certificate{tlsClientCerts},
+					MinVersion:   tls.VersionTLS12,
 				},
 			},
 		}, nil
@@ -419,9 +419,9 @@ func makePrometheusCAClient(caFilePath string, tlsCertFilePath string, tlsKeyFil
 
 	return &http.Client{
 		Transport: &http.Transport{
-			//nolint:gosec
 			TLSClientConfig: &tls.Config{
-				RootCAs: pool,
+				RootCAs:    pool,
+				MinVersion: tls.VersionTLS12,
 			},
 		},
 	}, nil


### PR DESCRIPTION
Having no explicit `MinVersion` is reported by [gosec] as G402 (CWE-295): `TLS MinVersion too low`

Using MinVersion: tls.VersionTLS12 because it's what client-go uses:

https://github.com/kubernetes/client-go/blob/1ac8d459351e21458fd1041f41e43403eadcbdba/transport/transport.go#L92

That way, the Kubernetes API client and the Prometheus client in `prometheus-adapter` use the same TLS config `MinVersion`.

[gosec]: https://github.com/securego/gosec
