### PR TITLE
Refactor adding logging flags

### DIFF
--- a/cmd/adapter/adapter.go
+++ b/cmd/adapter/adapter.go
@@ -19,7 +19,6 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"flag"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -151,10 +150,13 @@ func (cmd *PrometheusAdapter) addFlags() {
 	cmd.Flags().StringVar(&cmd.AdapterConfigFile, "config", cmd.AdapterConfigFile,
 		"Configuration file containing details of how to transform between Prometheus metrics "+
 			"and custom metrics API resources")
-	cmd.Flags().DurationVar(&cmd.MetricsRelistInterval, "metrics-relist-interval", cmd.MetricsRelistInterval, ""+
+	cmd.Flags().DurationVar(&cmd.MetricsRelistInterval, "metrics-relist-interval", cmd.MetricsRelistInterval,
 		"interval at which to re-list the set of all available metrics from Prometheus")
-	cmd.Flags().DurationVar(&cmd.MetricsMaxAge, "metrics-max-age", cmd.MetricsMaxAge, ""+
+	cmd.Flags().DurationVar(&cmd.MetricsMaxAge, "metrics-max-age", cmd.MetricsMaxAge,
 		"period for which to query the set of available metrics from Prometheus")
+
+	// Add logging flags
+	logs.AddFlags(cmd.Flags())
 }
 
 func (cmd *PrometheusAdapter) loadConfig() error {
@@ -295,10 +297,6 @@ func main() {
 	cmd.OpenAPIConfig.Info.Version = "1.0.0"
 
 	cmd.addFlags()
-	// make sure we get klog flags
-	local := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	logs.AddGoFlags(local)
-	cmd.Flags().AddGoFlagSet(local)
 	if err := cmd.Flags().Parse(os.Args); err != nil {
 		klog.Fatalf("unable to parse flags: %v", err)
 	}

--- a/cmd/adapter/adapter_test.go
+++ b/cmd/adapter/adapter_test.go
@@ -178,3 +178,34 @@ func TestParseHeaderArgs(t *testing.T) {
 		}
 	}
 }
+
+func TestFlags(t *testing.T) {
+	cmd := &PrometheusAdapter{
+		PrometheusURL: "https://localhost",
+	}
+	cmd.addFlags()
+
+	flags := cmd.FlagSet
+	if flags == nil {
+		t.Fatalf("FlagSet should not be nil")
+	}
+
+	expectedFlags := []struct {
+		flag         string
+		defaultValue string
+	}{
+		{flag: "v", defaultValue: "0"},                              // logging flag (klog)
+		{flag: "prometheus-url", defaultValue: "https://localhost"}, // default is set in cmd
+	}
+
+	for _, e := range expectedFlags {
+		flag := flags.Lookup(e.flag)
+		if flag == nil {
+			t.Errorf("Flag %q expected to be present, was absent", e.flag)
+			continue
+		}
+		if flag.DefValue != e.defaultValue {
+			t.Errorf("Expected default value %q for flag %q, got %q", e.defaultValue, e.flag, flag.DefValue)
+		}
+	}
+}


### PR DESCRIPTION
Instead of using `logs.AddGoFlags(local)` to add logging flags to Go `flags.FlagSet`, then adding them to `github.com/spf13/pflag.FlagSet`, we directly add them to `github.com/spf13/pflag.FlagSet`.

/kind cleanup