### PR TITLE
golangci-lint: Add stylecheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     - nolintlint
     - revive
     - staticcheck
+    - stylecheck
     - typecheck
     - unconvert
     - unused

--- a/pkg/resourceprovider/provider.go
+++ b/pkg/resourceprovider/provider.go
@@ -199,7 +199,7 @@ func (p *resourceProvider) assignForPod(pod *metav1.PartialObjectMetadata, resul
 	}
 
 	containerMetrics := make(map[string]metrics.ContainerMetrics)
-	earliestTs := pmodel.Latest
+	earliestTS := pmodel.Latest
 
 	// organize all the CPU results
 	for _, cpu := range cpuRes {
@@ -211,8 +211,8 @@ func (p *resourceProvider) assignForPod(pod *metav1.PartialObjectMetadata, resul
 			}
 		}
 		containerMetrics[containerName].Usage[corev1.ResourceCPU] = *resource.NewMilliQuantity(int64(cpu.Value*1000.0), resource.DecimalSI)
-		if cpu.Timestamp.Before(earliestTs) {
-			earliestTs = cpu.Timestamp
+		if cpu.Timestamp.Before(earliestTS) {
+			earliestTS = cpu.Timestamp
 		}
 	}
 
@@ -226,8 +226,8 @@ func (p *resourceProvider) assignForPod(pod *metav1.PartialObjectMetadata, resul
 			}
 		}
 		containerMetrics[containerName].Usage[corev1.ResourceMemory] = *resource.NewMilliQuantity(int64(mem.Value*1000.0), resource.BinarySI)
-		if mem.Timestamp.Before(earliestTs) {
-			earliestTs = mem.Timestamp
+		if mem.Timestamp.Before(earliestTS) {
+			earliestTS = mem.Timestamp
 		}
 	}
 
@@ -250,7 +250,7 @@ func (p *resourceProvider) assignForPod(pod *metav1.PartialObjectMetadata, resul
 			CreationTimestamp: metav1.Now(),
 		},
 		// store the time in the final format
-		Timestamp: metav1.NewTime(earliestTs.Time()),
+		Timestamp: metav1.NewTime(earliestTS.Time()),
 		Window:    metav1.Duration{Duration: p.window},
 	}
 


### PR DESCRIPTION
Similar to https://github.com/kubernetes-sigs/custom-metrics-apiserver/pull/128

`earliestTs` is renamed `earliestTS` to comply to [Go naming conventions](https://github.com/golang/go/wiki/CodeReviewComments#initialisms).