### PR TITLE
fix: use dl.k8s.io, not kubernetes-release bucket

### DIFF
--- a/test/run-e2e-tests.sh
+++ b/test/run-e2e-tests.sh
@@ -85,7 +85,7 @@ if [[ -n "${KIND_E2E}" ]]; then
     if [[ -z "${SKIP_INSTALL}" ]]; then
         BIN="${E2E_DIR}/bin"
         mkdir -p "${BIN}"
-        curl -Lo "${BIN}/kubectl" "https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl" && chmod +x "${BIN}/kubectl"
+        curl -Lo "${BIN}/kubectl" "https://dl.k8s.io/release/${K8S_VERSION}/bin/linux/amd64/kubectl" && chmod +x "${BIN}/kubectl"
         curl -Lo "${BIN}/kind" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64" && chmod +x "${BIN}/kind"
         export PATH="${BIN}:${PATH}"
     fi


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind deprecation

#### What this PR does / why we need it:
There are still references to https://storage.googleapis.com/kubernetes-release instead of https://dl.k8s.io/

dl.k8s.io is the correct advertised download host and will eventually move to be fastly shielding a fully community-owned bucket

ref: https://github.com/kubernetes/k8s.io/issues/2396