### PR TITLE
optimize pod informers transformers

### DIFF
--- a/cmd/adapter/adapter.go
+++ b/cmd/adapter/adapter.go
@@ -277,7 +277,12 @@ func (cmd *PrometheusAdapter) addResourceMetricsAPI(promClient prom.Client, stop
 		return err
 	}
 
-	go podInformer.Informer().Run(stopCh)
+	ifm := podInformer.Informer()
+
+	if err := ifm.SetTransform(partialMetadataRemoveAll); err != nil {
+		return err
+	}
+	go ifm.Run(stopCh)
 
 	return nil
 }

--- a/cmd/adapter/transformers.go
+++ b/cmd/adapter/transformers.go
@@ -17,8 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 )

--- a/cmd/adapter/transformers.go
+++ b/cmd/adapter/transformers.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ cache.TransformFunc = partialMetadataRemoveAll
+
+// partialMetadataRemoveAll implements a cache.TransformFunc that removes
+// annotations and managed
+// fields from PartialObjectMetadata.
+func partialMetadataRemoveAll(obj interface{}) (interface{}, error) {
+	partialMeta, ok := obj.(*metav1.PartialObjectMetadata)
+	if !ok {
+		return nil, fmt.Errorf("internal error: cannot cast object %#+v to PartialObjectMetadata", obj)
+	}
+	partialMeta.Annotations = nil
+	partialMeta.ManagedFields = nil
+	return partialMeta, nil
+}

--- a/cmd/adapter/transformers.go
+++ b/cmd/adapter/transformers.go
@@ -31,7 +31,9 @@ var _ cache.TransformFunc = partialMetadataRemoveAll
 func partialMetadataRemoveAll(obj interface{}) (interface{}, error) {
 	partialMeta, ok := obj.(*metav1.PartialObjectMetadata)
 	if !ok {
-		return nil, fmt.Errorf("internal error: cannot cast object %#+v to PartialObjectMetadata", obj)
+		// Don't do anything if the cast isn't successful.
+		// The object might be of type "cache.DeletedFinalStateUnknown".
+		return obj, nil
 	}
 	partialMeta.Annotations = nil
 	partialMeta.ManagedFields = nil


### PR DESCRIPTION
The optimization has been inspired by https://github.com/cert-manager/cert-manager/pull/5966

By stripping the rest of the metadata, we can save a bit of memory on clusters with lots of pods.