### PR TITLE
Adding support to dynamically discover metrics configs across all namespaces in the cluster

### DIFF
--- a/pkg/custom-provider/provider_test.go
+++ b/pkg/custom-provider/provider_test.go
@@ -45,7 +45,7 @@ func setupPrometheusProvider() (provider.CustomMetricsProvider, *fakeprom.FakePr
 	namers, err := naming.NamersFromConfig(cfg.Rules, restMapper())
 	Expect(err).NotTo(HaveOccurred())
 
-	prov, _ := NewPrometheusProvider(restMapper(), fakeKubeClient, fakeProm, namers, fakeProviderUpdateInterval, fakeProviderStartDuration)
+	prov, _ := NewPrometheusProvider(restMapper(), fakeKubeClient, fakeProm, namers, fakeProviderUpdateInterval, fakeProviderStartDuration, false, "")
 
 	containerSel := prom.MatchSeries("", prom.NameMatches("^container_.*"), prom.LabelNeq("container", "POD"), prom.LabelNeq("namespace", ""), prom.LabelNeq("pod", ""))
 	namespacedSel := prom.MatchSeries("", prom.LabelNeq("namespace", ""), prom.NameNotMatches("^container_.*"))


### PR DESCRIPTION
It'd be great if the adapter could dynamically discover metrics configurations across all namespaces in the cluster. This would be helpful in scenarios where application developers can add Prometheus rules for HPA in their Helm chart without needing to touch the adapter configuration.

A similar ask is present in https://github.com/kubernetes-sigs/prometheus-adapter/issues/662, but I've chosen to add support using `ConfigMap` since the adapter already uses that instead of adding a new CRD.