### PR TITLE
pkg/naming: shorten regexp when matching many similar names

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -196,8 +196,8 @@ Additionally, there are two advanced fields that are "raw" forms of other
 fields:
 
 - `LabelValuesByName`: a map mapping the labels and values from the
-  `LabelMatchers` field.  The values are pre-joined by `|`
-  (for used with the `=~` matcher in Prometheus).
+  `LabelMatchers` field. The values are in regular expression format
+  (for use with the `=~` matcher in Prometheus).
 - `GroupBySlice`: the slice form of `GroupBy`.
 
 In general, you'll probably want to use the `Series`, `LabelMatchers`, and

--- a/pkg/custom-provider/series_registry_test.go
+++ b/pkg/custom-provider/series_registry_test.go
@@ -164,7 +164,7 @@ var _ = Describe("Series Registry", func() {
 				resourceNames:  []string{"somepod1", "somepod2"},
 				metricSelector: labels.Everything(),
 
-				expectedQuery: "sum(container_some_usage{namespace=\"somens\",pod=~\"somepod1|somepod2\",container!=\"POD\"}) by (pod)",
+				expectedQuery: "sum(container_some_usage{namespace=\"somens\",pod=~\"somepod[12]\",container!=\"POD\"}) by (pod)",
 			},
 			{
 				title:          "container metrics counter",
@@ -173,7 +173,7 @@ var _ = Describe("Series Registry", func() {
 				resourceNames:  []string{"somepod1", "somepod2"},
 				metricSelector: labels.Everything(),
 
-				expectedQuery: "sum(rate(container_some_count_total{namespace=\"somens\",pod=~\"somepod1|somepod2\",container!=\"POD\"}[1m])) by (pod)",
+				expectedQuery: "sum(rate(container_some_count_total{namespace=\"somens\",pod=~\"somepod[12]\",container!=\"POD\"}[1m])) by (pod)",
 			},
 			{
 				title:          "container metrics seconds counter",
@@ -182,7 +182,7 @@ var _ = Describe("Series Registry", func() {
 				resourceNames:  []string{"somepod1", "somepod2"},
 				metricSelector: labels.Everything(),
 
-				expectedQuery: "sum(rate(container_some_time_seconds_total{namespace=\"somens\",pod=~\"somepod1|somepod2\",container!=\"POD\"}[1m])) by (pod)",
+				expectedQuery: "sum(rate(container_some_time_seconds_total{namespace=\"somens\",pod=~\"somepod[12]\",container!=\"POD\"}[1m])) by (pod)",
 			},
 			// namespaced metrics
 			{

--- a/pkg/naming/metrics_query.go
+++ b/pkg/naming/metrics_query.go
@@ -364,12 +364,6 @@ func compactRegexp(values []string) (string, error) {
 			return "", ErrMalformedQuery
 		}
 	}
-	if len(values) == 0 {
-		return "", nil
-	}
-	if len(values) == 1 {
-		return values[0], nil
-	}
 	expr := strings.Join(values, "|")
 	re, err := syntax.Parse(expr, syntax.POSIX)
 	if err != nil {


### PR DESCRIPTION
Fixes #668.

Pods from a deployment will have long names like:

1. foobar-59c8d74c75-9gv24
2. foobar-59c8d74c75-dhfbj
3. foobar-59c8d74c75-kggvk
4. foobar-59c8d74c75-nd8jm
5. foobar-59c8d74c75-nqctr
6. foobar-59c8d74c75-pxlnd
7. foobar-59c8d74c75-rnxk7
8. foobar-59c8d74c75-rpj7q
9. foobar-59c8d74c75-vl6n6
10. foobar-59c8d74c75-xhvp4

The naive regexp that matches these pods is `foobar-59c8d74c75-9gv24|foobar-59c8d74c75-dhfbj|foobar-59c8d74c75-kggvk|foobar-59c8d74c75-nd8jm|foobar-59c8d74c75-nqctr|foobar-59c8d74c75-pxlnd|foobar-59c8d74c75-rnxk7|foobar-59c8d74c75-rpj7q|foobar-59c8d74c75-vl6n6|foobar-59c8d74c75-xhvp4` (len=239).

A shorter regexp that factors out the shared prefixes and matches the same pods is `foobar-59c8d74c75-(9gv24|dhfbj|kggvk|n(d8jm|qctr)|pxlnd|r(nxk7|pj7q)|vl6n6|xhvp4)` (len=81).

A similar set of only 5 pods achieves 59% compression. This example with 10 pods achieves 66% compression. At 20 pods it's ~71%, at 40 pods it's ~73%, at 80 pods it's ~74%, and at 200 pods it starts to converge to ~75%. The savings ultimately depend on the length of the deployment name, but even pods with short deployment names (e.g. `foobar`) still benefit because the replicaset hash (e.g. `59c8d74c75`) contributes a lot of redundancy.

Instead of trying to implement this transformation directly, this change lets the `regexp/syntax` package do all the heavy lifting. In some cases this doesn't result in the shortest possible string (e.g. some short prefix repetitions are more optimal than complete prefix factoring: `nd8jm|nqctr` vs `n(d8jm|qctr)`), but writing and maintaining a separate implementation isn't worth it to get at these crumbs.