### PR TITLE
fix(docs): correct malformed YAML keys in sample-config.yaml

### DIFF
--- a/docs/sample-config.yaml
+++ b/docs/sample-config.yaml
@@ -27,7 +27,7 @@ rules:
   # This is a Go template where the `.Series` and `.LabelMatchers` string values
   # are available, and the delimiters are `<<` and `>>` to avoid conflicts with
   # the prometheus query language
-  metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)"
+  metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)'
 
 # this rule matches cumulative cAdvisor metrics not measured in seconds
 - seriesQuery: '{__name__=~"^container_.*_total",container!="POD",namespace!="",pod!=""}'
@@ -39,7 +39,7 @@ rules:
   # since this is a superset of the query above, we introduce an additional filter here
   - isNot: "^container_.*_seconds_total$"
   name: {matches: "^container_(.*)_total$"}
-  metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)"
+  metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)'
 
 # this rule matches cumulative non-cAdvisor metrics
 - seriesQuery: '{namespace!="",__name__!="^container_.*"}'
@@ -52,7 +52,7 @@ rules:
     # Group will be converted to a form acceptible for use as a label automatically.
     template: "<<.Resource>>"
     # if we wanted to, we could also specify overrides here
-  metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)"
+  metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)'
 
 # this rule matches only a single metric, explicitly naming it something else
 # It's series query *must* return only a single metric family


### PR DESCRIPTION
Fixes: #697 
Replace double quotes with single quotes in metricsQuery to avoid parsing errors.