### PR TITLE
Fix sample-config YAML quoting and refresh documentation

### DIFF
--- a/docs/config-walkthrough.md
+++ b/docs/config-walkthrough.md
@@ -4,6 +4,13 @@ Configuration Walkthroughs
 *If you're looking for reference documentation on configuration, please
 read the [configuration reference](/docs/config.md)*
 
+For a complete, working example configuration, see
+[sample-config.yaml](sample-config.yaml). When writing `metricsQuery`
+values that contain Prometheus label matchers with double quotes (for
+example `container!="POD"`), wrap the entire value in **single quotes**
+in YAML so the inner double quotes are not parsed as YAML string
+delimiters.
+
 Per-pod HTTP Requests
 ---------------------
 
@@ -160,14 +167,14 @@ configuration, we should see discovery information at
   "groupVersion": "custom.metrics.k8s.io/v1beta1",
   "resources": [
     {
-      "name": "pods/http_requests_total",
+      "name": "pods/http_requests_per_second",
       "singularName": "",
       "namespaced": true,
       "kind": "MetricValueList",
       "verbs": ["get"]
     },
     {
-      "name": "namespaces/http_requests_total",
+      "name": "namespaces/http_requests_per_second",
       "singularName": "",
       "namespaced": false,
       "kind": "MetricValueList",

--- a/docs/config.md
+++ b/docs/config.md
@@ -48,7 +48,7 @@ rules:
   # This is a Go template where the `.Series` and `.LabelMatchers` string values
   # are available, and the delimiters are `<<` and `>>` to avoid conflicts with
   # the prometheus query language
-  metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)"
+  metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)'
 ```
 
 Discovery
@@ -168,7 +168,14 @@ metric.  It's controlled by the `metricsQuery` field.
 
 The `metricsQuery` field is a Go template that gets turned into
 a Prometheus query, using input from a particular call to the custom
-metrics API. A given call to the custom metrics API is distilled down to
+metrics API.
+
+When the Prometheus query contains double quotes (for example
+`container!="POD"`), wrap the entire `metricsQuery` value in single
+quotes in YAML to avoid parse errors. See [sample-config.yaml](sample-config.yaml)
+for a working example.
+
+A given call to the custom metrics API is distilled down to
 a metric name, a group-resource, and one or more objects of that
 group-resource.  These get turned into the following fields in the
 template:
@@ -211,5 +218,5 @@ For example:
 
 ```yaml
 # convert cumulative cAdvisor metrics into rates calculated over 2 minutes
-metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)"
+metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)'
 ```

--- a/docs/sample-config.yaml
+++ b/docs/sample-config.yaml
@@ -27,7 +27,7 @@ rules:
   # This is a Go template where the `.Series` and `.LabelMatchers` string values
   # are available, and the delimiters are `<<` and `>>` to avoid conflicts with
   # the prometheus query language
-  metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)"
+  metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)'
 
 # this rule matches cumulative cAdvisor metrics not measured in seconds
 - seriesQuery: '{__name__=~"^container_.*_total",container!="POD",namespace!="",pod!=""}'
@@ -39,7 +39,7 @@ rules:
   # since this is a superset of the query above, we introduce an additional filter here
   - isNot: "^container_.*_seconds_total$"
   name: {matches: "^container_(.*)_total$"}
-  metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)"
+  metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)'
 
 # this rule matches cumulative non-cAdvisor metrics
 - seriesQuery: '{namespace!="",__name__!="^container_.*"}'
@@ -52,7 +52,7 @@ rules:
     # Group will be converted to a form acceptible for use as a label automatically.
     template: "<<.Resource>>"
     # if we wanted to, we could also specify overrides here
-  metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)"
+  metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[2m])) by (<<.GroupBy>>)'
 
 # this rule matches only a single metric, explicitly naming it something else
 # It's series query *must* return only a single metric family

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -25,9 +25,8 @@ Kubernetes 1.9+), or enabling custom metrics autoscaling support will
 disable CPU autoscaling support.
 
 Note that most of the API versions in this walkthrough target Kubernetes
-1.9+.  Note that current versions of the adapter *only* work with
-Kubernetes 1.8+.  Version 0.1.0 works with Kubernetes 1.7, but is
-significantly different.
+1.27+.  See the [compatibility matrix](README.md#compatibility-matrix) in
+the README for supported Kubernetes versions.
 
 ### Binaries and Images
 


### PR DESCRIPTION
#### What this PR does / why we need it

Fixes YAML parse errors in `docs/sample-config.yaml` caused by double-quoted
`metricsQuery` values containing inner double quotes (fixes #697).

Updates configuration documentation for accuracy and clarity (fixes #679):
- Add YAML quoting guidance and link to working sample config
- Fix incorrect metric names in config-walkthrough discovery example
- Update walkthrough Kubernetes version references

#### Which issue(s) this PR fixes

Fixes #697
Fixes #679

#### Special notes for your reviewer

Documentation-only change. Verified `docs/sample-config.yaml` parses with PyYAML.

```release-note
NONE
```